### PR TITLE
feat: flagd gherkin suite and flags

### DIFF
--- a/.gherkin-lintrc
+++ b/.gherkin-lintrc
@@ -14,7 +14,9 @@
       "Feature": 0,
       "Background": 2,
       "Scenario": 2,
-      "Step": 4
+      "Step": 4,
+      "Examples": 4,
+      "example": 6
     }
   ],
   "no-trailing-spaces": "on",

--- a/README.md
+++ b/README.md
@@ -21,10 +21,17 @@ For details on the sync-testbed, see [sync/README.me](sync/README.md)
 
 The [gherkin/](gherkin/) dir includes a set of [_gherkin_](https://cucumber.io/docs/gherkin/) tests that define expected behavior associated with the configurations defined in the flagd-testbed (see [flags/](flags/)).
 Combined with the _flagd-provider_ for the associated SDK and the flagd-testbed, these comprise a complete integration test suite.
-They include tests for:
+
+Included suites:
+
+[flagd.feature](gherkin/flagd.feature) includes tests relevant to flagd and all flagd providers:
 * default value (zero-value) handling (some proto3 implementations handle these inconsistently).
 * basic event handling
+
+[flagd-json-evaluator.feature](gherkin/flagd-json-evaluator.feature) includes tests relevant to flagd and in-process providers:
 * custom JSONLogic operators (`starts_with`, `ends_with`, `fractional`, `sem_ver`)
+* evaluator reuse via `$ref`
+
 
 ### Lint Gherkin files
 

--- a/README.md
+++ b/README.md
@@ -16,3 +16,19 @@ The _sync_-testbed_ container is a docker image built on conforming to the sync.
 It features an identical set of flags to the [flagd-testbed container](#flagd-testbed-container)
 
 For details on the sync-testbed, see [sync/README.me](sync/README.md)
+
+## Gherkin test suite
+
+The [gherkin/](gherkin/) dir includes a set of [_gherkin_](https://cucumber.io/docs/gherkin/) tests that define expected behavior associated with the configurations defined in the flagd-testbed (see [flags/](flags/)).
+Combined with the _flagd-provider_ for the associated SDK and the flagd-testbed, these comprise a complete integration test suite.
+They include tests for:
+* default value (zero-value) handling (some proto3 implementations handle these inconsistently).
+* basic event handling
+* custom JSONLogic operators (`starts_with`, `ends_with`, `fractional`, `sem_ver`)
+
+### Lint Gherkin files
+
+The Gherkin files structure can be linted using [gherkin-lint](https://github.com/vsiakka/gherkin-lint). The following commands require Node.js 10 or later.
+
+1. npm install
+1. npm run gherkin-lint

--- a/flagd/Dockerfile
+++ b/flagd/Dockerfile
@@ -1,4 +1,5 @@
-FROM ghcr.io/open-feature/flagd:v0.6.3 as flagd
+# we NEED flagd v0.6.4 as a minimum
+FROM ghcr.io/open-feature/flagd:v0.6.4 as flagd
 
 FROM busybox:1.36
 
@@ -7,4 +8,8 @@ COPY flags/* .
 COPY scripts/* .
 LABEL org.opencontainers.image.source = "https://github.com/open-feature/test-harness"
 
-ENTRYPOINT ["sh", "wrapper.sh", "./flagd", "start", "-f", "file:testing-flags.json", "-f", "file:changing-flag.json"]
+ENTRYPOINT ["sh", "wrapper.sh", "./flagd", "start", \
+    "-f", "file:testing-flags.json", \
+    "-f", "file:changing-flag.json", \
+    "-f", "file:custom-ops.json", \
+    "-f", "file:zero-flags.json"]

--- a/flagd/Dockerfile
+++ b/flagd/Dockerfile
@@ -12,4 +12,5 @@ ENTRYPOINT ["sh", "wrapper.sh", "./flagd", "start", \
     "-f", "file:testing-flags.json", \
     "-f", "file:changing-flag.json", \
     "-f", "file:custom-ops.json", \
+    "-f", "file:evaluator-refs.json", \
     "-f", "file:zero-flags.json"]

--- a/flagd/Dockerfile
+++ b/flagd/Dockerfile
@@ -6,7 +6,7 @@ FROM busybox:1.36
 COPY --from=flagd /flagd-build /flagd
 COPY flags/* .
 COPY scripts/* .
-LABEL org.opencontainers.image.source = "https://github.com/open-feature/test-harness"
+LABEL org.opencontainers.image.source = "https://github.com/open-feature/flagd-testbed"
 
 ENTRYPOINT ["sh", "wrapper.sh", "./flagd", "start", \
     "-f", "file:testing-flags.json", \

--- a/flags/custom-ops.json
+++ b/flags/custom-ops.json
@@ -1,0 +1,104 @@
+{
+  "flags": {
+    "fractional-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "clubs": "clubs",
+        "diamonds": "diamonds",
+        "hearts": "hearts",
+        "spades": "spades",
+        "wild": "wild"
+      },
+      "defaultVariant": "wild",
+      "targeting": {
+        "fractional": [
+          { "var": "user.name" },
+          [ "clubs", 25 ],
+          [ "diamonds", 25 ],
+          [ "hearts", 25 ],
+          [ "spades", 25 ]
+        ]
+      }
+    },
+    "starts-ends-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "prefix": "prefix",
+        "postfix": "postfix",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "starts_with": [{"var": "id"}, "abc"]
+          },
+          "prefix", {
+            "if": [
+              {
+                "ends_with": [{"var": "id"}, "xyz"]
+              },
+              "postfix", "none"
+            ]
+          }
+        ]
+      }
+    },
+    "equal-greater-lesser-version-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "equal": "equal",
+        "greater": "greater",
+        "lesser": "lesser",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "sem_ver": [{"var": "version"}, "=", "2.0.0"]
+          },
+          "equal", {
+            "if": [
+              {
+                "sem_ver": [{"var": "version"}, ">", "2.0.0"]
+              },
+              "greater", {
+                "if": [
+                  {
+                    "sem_ver": [{"var": "version"}, "<", "2.0.0"]
+                  },
+                  "lesser", "none"
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "major-minor-version-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "minor": "minor",
+        "major": "major",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "sem_ver": [{"var": "version"}, "~", "3.0.0"]
+          },
+          "minor", {
+            "if": [
+              {
+                "sem_ver": [{"var": "version"}, "^", "3.0.0"]
+              },
+              "major", "none"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/flags/evaluator-refs.json
+++ b/flags/evaluator-refs.json
@@ -1,0 +1,52 @@
+{
+  "flags": {
+    "some-email-targeted-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "hi": "hi",
+        "bye": "bye",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "$ref": "is_ballmer"
+          },
+          "hi",
+          "bye"
+        ]
+      }
+    },
+    "some-other-email-targeted-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "yes": "yes",
+        "no": "no",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "$ref": "is_ballmer"
+          },
+          "yes",
+          "no"
+        ]
+      }
+    }
+  },
+  "$evaluators": {
+    "is_ballmer": {
+      "==": [
+        "ballmer@macrosoft.com",
+        {
+          "var": [
+            "email"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/flags/testing-flags.json
+++ b/flags/testing-flags.json
@@ -8,23 +8,7 @@
       },
       "defaultVariant": "on"
     },
-    "boolean-flag-copy": {
-      "state": "ENABLED",
-      "variants": {
-        "on": true,
-        "off": false
-      },
-      "defaultVariant": "on"
-    },
     "string-flag": {
-      "state": "ENABLED",
-      "variants": {
-        "greeting": "hi",
-        "parting": "bye"
-      },
-      "defaultVariant": "greeting"
-    },
-    "string-flag-copy": {
       "state": "ENABLED",
       "variants": {
         "greeting": "hi",
@@ -40,14 +24,6 @@
       },
       "defaultVariant": "ten"
     },
-    "integer-flag-copy": {
-      "state": "ENABLED",
-      "variants": {
-        "one": 1,
-        "ten": 10
-      },
-      "defaultVariant": "ten"
-    },
     "float-flag": {
       "state": "ENABLED",
       "variants": {
@@ -56,27 +32,7 @@
       },
       "defaultVariant": "half"
     },
-    "float-flag-copy": {
-      "state": "ENABLED",
-      "variants": {
-        "tenth": 0.1,
-        "half": 0.5
-      },
-      "defaultVariant": "half"
-    },
     "object-flag": {
-      "state": "ENABLED",
-      "variants": {
-        "empty": {},
-        "template": {
-          "showImages": true,
-          "title": "Check out these pics!",
-          "imagesPerPage": 100
-        }
-      },
-      "defaultVariant": "template"
-    },
-    "object-flag-copy": {
       "state": "ENABLED",
       "variants": {
         "empty": {},

--- a/flags/zero-flags.json
+++ b/flags/zero-flags.json
@@ -1,0 +1,36 @@
+{
+  "flags": {
+    "boolean-zero-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "zero": false,
+        "non-zero": true
+      },
+      "defaultVariant": "zero"
+    },
+    "string-zero-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "zero": "",
+        "non-zero": "str"
+      },
+      "defaultVariant": "zero"
+    },
+    "integer-zero-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "zero": 0,
+        "non-zero": 1
+      },
+      "defaultVariant": "zero"
+    },
+    "float-zero-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "zero": 0.0,
+        "non-zero": 1.0
+      },
+      "defaultVariant": "zero"
+    }
+  }
+}

--- a/gherkin/flagd-json-evaluator.feature
+++ b/gherkin/flagd-json-evaluator.feature
@@ -1,0 +1,63 @@
+Feature: flagd json evaluation
+
+  # This test suite contains scenarios to test the json-evaluation of flagd and flag-in-process providers.
+  # It's associated with the flags configured in flags/changing-flag.json, flags/zero-flags.json, flags/custom-ops.json and evaluator-refs.json.
+  # It should be used in conjunection with the suites supplied by the OpenFeature specification.
+
+  Background:
+    Given a flagd provider is set
+
+  # evaluator refs
+  Scenario Outline: Evaluator reuse
+    When a string flag with key <key> is evaluated with default value "fallback"
+    And a context containing a key "email", with value "ballmer@macrosoft.com"
+    Then the returned value should be <value>
+    Examples:
+      | key                            | value |
+      | some-email-targeted-flag       | hi    |
+      | some-other-email-targeted-flag | yes   |
+
+  # custom operators
+  Scenario Outline: Fractional operator
+    When a string flag with key "fractional-flag" is evaluated with default value "fallback"
+    And a context containing a nested property with outer key "user" and inner key "name", with value <name>
+    Then the returned value should be <value>
+    Examples:
+      | name  | value    |
+      | jack  | clubs    |
+      | queen | diamonds |
+      | ace   | hearts   |
+      | joker | spades   |
+
+  Scenario Outline: Substring operators
+    When a string flag with key "starts-ends-flag" is evaluated with default value "fallback"
+    And a context containing a key "id", with value <id>
+    Then the returned value should be <value>
+    Examples:
+      | id     | value   |
+      | abcdef | prefix  |
+      | uvwxyz | postfix |
+      | abcxyz | prefix  |
+      | lmnopq | nomatch |
+
+  Scenario Outline: Semantic version operator numeric comparision
+    When a string flag with key "equal-greater-lesser-version-flag" is evaluated with default value "fallback"
+    And a context containing a key "version", with value <version>
+    Then the returned value should be <value>
+    Examples:
+      | version     | value   |
+      | 2.0.0       | equal   |
+      | 2.1.0       | greater |
+      | 1.9.0       | lesser  |
+      | 2.0.0-alpha | lesser  |
+      | 2.0.0.0     | invalid |
+
+  Scenario Outline: Semantic version operator semantic comparision
+    When a string flag with key "major-minor-version-flag" is evaluated with default value "fallback"
+    And a context containing a key "version", with value <version>
+    Then the returned value should be <value>
+    Examples:
+      | version | value |
+      | 3.0.1   | minor |
+      | 3.1.0   | major |
+      | 4.0.0   | none  |

--- a/gherkin/flagd.feature
+++ b/gherkin/flagd.feature
@@ -34,4 +34,3 @@ Feature: flagd providers
   Scenario: Resolves float zero value
     When a float flag with key "float-zero-flag" is evaluated with default value 0.1
     Then the resolved float value should be 0.0
-    

--- a/gherkin/flagd.feature
+++ b/gherkin/flagd.feature
@@ -34,3 +34,4 @@ Feature: flagd providers
   Scenario: Resolves float zero value
     When a float flag with key "float-zero-flag" is evaluated with default value 0.1
     Then the resolved float value should be 0.0
+    

--- a/gherkin/flagd.feature
+++ b/gherkin/flagd.feature
@@ -1,0 +1,81 @@
+Feature: flagd providers
+
+  # This test suite contains scenarios to test flagd providers (both RPC and in-process).
+  # It's associated with the flags configured in flags/custom-ops.json and flags/zero-flags.json
+  # It should be used in conjunection with the suites supplied by the OpenFeature specification
+
+  Background:
+    Given a flagd provider is set
+
+  # events
+  Scenario: Provider ready event
+    When a PROVIDER_READY handler is added
+    Then the PROVIDER_READY handler must run
+
+  Scenario: Flag change event
+    When a PROVIDER_CONFIGURATION_CHANGED handler is added
+    And a flag with key "changing-flag" is modified
+    Then the PROVIDER_CONFIGURATION_CHANGED handler must run
+    And the event details must indicate "changing-flag" was altered
+
+  # zero evaluation
+  Scenario: Resolves boolean zero value
+    When a boolean flag with key "boolean-zero-flag" is evaluated with default value "true"
+    Then the resolved boolean value should be "false"
+
+  Scenario: Resolves string zero value
+    When a string flag with key "string-zero-flag" is evaluated with default value "hi"
+    Then the resolved string value should be ""
+
+  Scenario: Resolves integer zero value
+    When an integer flag with key "integer-zero-flag" is evaluated with default value 1
+    Then the resolved integer value should be 0
+
+  Scenario: Resolves float zero value
+    When a float flag with key "float-zero-flag" is evaluated with default value 0.1
+    Then the resolved float value should be 0.0
+
+  # custom operators
+  Scenario Outline: Fractional operator
+    When a string flag with key "fractional-flag" is evaluated with default value "fallback"
+    And a context containing a nested property with outer key "user" and inner key "name", with value <name>
+    Then the returned value should be <value>
+    Examples:
+      | name  | value    |
+      | jack  | clubs    |
+      | queen | diamonds |
+      | ace   | hearts   |
+      | joker | spades   |
+
+  Scenario Outline: Substring operators
+    When a string flag with key "starts-ends-flag" is evaluated with default value "fallback"
+    And a context containing a key "id", with value <id>
+    Then the returned value should be <value>
+    Examples:
+      | id     | value   |
+      | abcdef | prefix  |
+      | uvwxyz | postfix |
+      | abcxyz | prefix  |
+      | lmnopq | nomatch |
+
+  Scenario Outline: Semantic version operator numeric comparision
+    When a string flag with key "equal-greater-lesser-version-flag" is evaluated with default value "fallback"
+    And a context containing a key "version", with value <version>
+    Then the returned value should be <value>
+    Examples:
+      | version     | value   |
+      | 2.0.0       | equal   |
+      | 2.1.0       | greater |
+      | 1.9.0       | lesser  |
+      | 2.0.0-alpha | lesser  |
+      | 2.0.0.0     | invalid |
+
+  Scenario Outline: Semantic version operator semantic comparision
+    When a string flag with key "major-minor-version-flag" is evaluated with default value "fallback"
+    And a context containing a key "version", with value <version>
+    Then the returned value should be <value>
+    Examples:
+      | version | value |
+      | 3.0.1   | minor |
+      | 3.1.0   | major |
+      | 4.0.0   | none  |

--- a/gherkin/flagd.feature
+++ b/gherkin/flagd.feature
@@ -1,8 +1,8 @@
 Feature: flagd providers
 
-  # This test suite contains scenarios to test flagd providers (both RPC and in-process).
-  # It's associated with the flags configured in flags/custom-ops.json and flags/zero-flags.json
-  # It should be used in conjunection with the suites supplied by the OpenFeature specification
+  # This test suite contains scenarios to test flagd providers.
+  # It's associated with the flags configured in flags/changing-flag.json and flags/zero-flags.json.
+  # It should be used in conjunection with the suites supplied by the OpenFeature specification.
 
   Background:
     Given a flagd provider is set
@@ -34,48 +34,3 @@ Feature: flagd providers
   Scenario: Resolves float zero value
     When a float flag with key "float-zero-flag" is evaluated with default value 0.1
     Then the resolved float value should be 0.0
-
-  # custom operators
-  Scenario Outline: Fractional operator
-    When a string flag with key "fractional-flag" is evaluated with default value "fallback"
-    And a context containing a nested property with outer key "user" and inner key "name", with value <name>
-    Then the returned value should be <value>
-    Examples:
-      | name  | value    |
-      | jack  | clubs    |
-      | queen | diamonds |
-      | ace   | hearts   |
-      | joker | spades   |
-
-  Scenario Outline: Substring operators
-    When a string flag with key "starts-ends-flag" is evaluated with default value "fallback"
-    And a context containing a key "id", with value <id>
-    Then the returned value should be <value>
-    Examples:
-      | id     | value   |
-      | abcdef | prefix  |
-      | uvwxyz | postfix |
-      | abcxyz | prefix  |
-      | lmnopq | nomatch |
-
-  Scenario Outline: Semantic version operator numeric comparision
-    When a string flag with key "equal-greater-lesser-version-flag" is evaluated with default value "fallback"
-    And a context containing a key "version", with value <version>
-    Then the returned value should be <value>
-    Examples:
-      | version     | value   |
-      | 2.0.0       | equal   |
-      | 2.1.0       | greater |
-      | 1.9.0       | lesser  |
-      | 2.0.0-alpha | lesser  |
-      | 2.0.0.0     | invalid |
-
-  Scenario Outline: Semantic version operator semantic comparision
-    When a string flag with key "major-minor-version-flag" is evaluated with default value "fallback"
-    And a context containing a key "version", with value <version>
-    Then the returned value should be <value>
-    Examples:
-      | version | value |
-      | 3.0.1   | minor |
-      | 3.1.0   | major |
-      | 4.0.0   | none  |

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -11,7 +11,7 @@ FROM busybox:1.36
 COPY --from=builder /src/sync .
 COPY flags/* .
 COPY scripts/* .
-LABEL org.opencontainers.image.source = "https://github.com/open-feature/test-harness"
+LABEL org.opencontainers.image.source = "https://github.com/open-feature/flagd-testbed"
 
 ENTRYPOINT ["sh", "wrapper.sh", "./sync", "start", \
     "-f", "testing-flags.json", \

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -13,4 +13,8 @@ COPY flags/* .
 COPY scripts/* .
 LABEL org.opencontainers.image.source = "https://github.com/open-feature/test-harness"
 
-ENTRYPOINT ["sh", "wrapper.sh", "./sync", "start", "-f", "testing-flags.json", "-f", "changing-flag.json"]
+ENTRYPOINT ["sh", "wrapper.sh", "./sync", "start", \
+    "-f", "testing-flags.json", \
+    "-f", "changing-flag.json", \
+    "-f", "custom-ops.json", \
+    "-f", "zero-flags.json"]

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -17,4 +17,5 @@ ENTRYPOINT ["sh", "wrapper.sh", "./sync", "start", \
     "-f", "testing-flags.json", \
     "-f", "changing-flag.json", \
     "-f", "custom-ops.json", \
+    "-f", "evaluator-refs.json", \
     "-f", "zero-flags.json"]


### PR DESCRIPTION
adds test suite (and containers) with.

`flagd.feature` includes tests relevant to flagd and all flagd providers:
* default value (zero-value) handling (some proto3 implementations handle these inconsistently).
* basic event handling

`flagd-json-evaluator.feature` includes tests relevant to flagd and in-process providers:
* custom JSONLogic operators (`starts_with`, `ends_with`, `fractional`, `sem_ver`)
* evaluator reuse via `$ref`

---

If you want, you can manually test some of this by calling flagd or the sync server from console once you build the containers

flagd: 

```shell
curl -X POST "http://localhost:8013/schema.v1.Service/ResolveString"       -d '{"flagKey":"fractional-flag","context":{"user":{"name":"ace"}}}' -H "Content-Type: application/json"

// {"value":"hearts","reason":"TARGETING_MATCH","variant":"hearts","metadata":{}}
```

sync (with [grpcurl](https://github.com/fullstorydev/grpcurl)):

```shell
grpcurl -import-path '/home/todd/Downloads'  -proto sync.proto -plaintext   localhost:9090 sync.v1.FlagSyncService/SyncFlags

// a bunch of streamed JSON, which will fire again every 1s
```
