### PR TITLE
feat: add tests for config edge cases

### DIFF
--- a/flagd/Dockerfile
+++ b/flagd/Dockerfile
@@ -1,5 +1,5 @@
 # we NEED flagd v0.6.4 as a minimum
-FROM ghcr.io/open-feature/flagd:v0.7.0 as flagd
+FROM ghcr.io/open-feature/flagd:v0.7.2 as flagd
 
 FROM busybox:1.36
 

--- a/flagd/Dockerfile
+++ b/flagd/Dockerfile
@@ -13,5 +13,5 @@ ENTRYPOINT ["sh", "change-flag-wrapper.sh", "./flagd", "start", \
     "-f", "file:changing-flag.json", \
     "-f", "file:custom-ops.json", \
     "-f", "file:evaluator-refs.json", \
-    "-f", "file:error-flags.json", \
+    "-f", "file:edge-case-flags.json", \
     "-f", "file:zero-flags.json"]

--- a/flagd/Dockerfile
+++ b/flagd/Dockerfile
@@ -13,4 +13,5 @@ ENTRYPOINT ["sh", "change-flag-wrapper.sh", "./flagd", "start", \
     "-f", "file:changing-flag.json", \
     "-f", "file:custom-ops.json", \
     "-f", "file:evaluator-refs.json", \
+    "-f", "file:error-flags.json", \
     "-f", "file:zero-flags.json"]

--- a/flagd/Dockerfile.unstable
+++ b/flagd/Dockerfile.unstable
@@ -1,5 +1,5 @@
 # we NEED flagd v0.6.4 as a minimum
-FROM ghcr.io/open-feature/flagd:v0.6.6 as flagd
+FROM ghcr.io/open-feature/flagd:v0.7.2 as flagd
 
 FROM busybox:1.36
 

--- a/flags/custom-ops.json
+++ b/flags/custom-ops.json
@@ -38,7 +38,14 @@
               {
                 "ends_with": [{"var": "id"}, "xyz"]
               },
-              "postfix", "none"
+              "postfix", {
+                "if": [
+                  {
+                    "ends_with": [{"var": "id"}, 3]
+                  },
+                  "fail", "none"
+                ]
+              }
             ]
           }
         ]
@@ -68,7 +75,14 @@
                   {
                     "sem_ver": [{"var": "version"}, "<", "2.0.0"]
                   },
-                  "lesser", "none"
+                  "lesser", {
+                    "if": [
+                      {
+                        "sem_ver": [{"var": "version"}, "=", "2.0.0.0"]
+                      },
+                      "fail", "none"
+                    ]
+                  }
                 ]
               }
             ]

--- a/flags/edge-case-flags.json
+++ b/flags/edge-case-flags.json
@@ -1,5 +1,16 @@
 {
   "flags": {
+    "targeting-null-variant-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "one": 1,
+        "two": 2
+      },
+      "defaultVariant": "two",
+      "targeting": {
+        "if": [true, null, "one"]
+      }
+    },
     "error-targeting-flag": {
       "state": "ENABLED",
       "variants": {

--- a/flags/error-flags.json
+++ b/flags/error-flags.json
@@ -1,0 +1,37 @@
+{
+  "flags": {
+    "error-targeting-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "one": 1,
+        "two": 2
+      },
+      "defaultVariant": "two",
+      "targeting": {
+        "invalid": ["this is not valid targeting"]
+      }
+    },
+    "missing-variant-targeting-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "one": 1,
+        "two": 2
+      },
+      "defaultVariant": "two",
+      "targeting": {
+        "if": [true, "three", "one"]
+      }
+    },
+    "non-string-variant-targeting-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "false": 1,
+        "true": 2
+      },
+      "defaultVariant": "false",
+      "targeting": {
+        "if": [true, true, false]
+      }
+    }
+  }
+}

--- a/flags/testing-flags.json
+++ b/flags/testing-flags.json
@@ -102,6 +102,31 @@
         ]
       }
     },
+    "timestamp-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "past": -1,
+        "future": 1,
+        "none": 0
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            ">": [ { "var": "$flagd.timestamp" }, { "var": "time" }  ]
+          },
+          "past",
+          {
+            "if": [
+              {
+              "<": [ { "var": "$flagd.timestamp" }, { "var": "time" }  ]
+              },
+              "future", "none"
+            ]
+          }
+        ]
+      }
+    },
     "wrong-flag": {
       "state": "ENABLED",
       "variants": {

--- a/gherkin/flagd-json-evaluator.feature
+++ b/gherkin/flagd-json-evaluator.feature
@@ -28,6 +28,7 @@ Feature: flagd json evaluation
       | "queen" | "clubs"    |
       | "ten"   | "diamonds" |
       | "nine"  | "hearts"   |
+      | 3       | "wild"     |
 
   Scenario Outline: Substring operators
     When a string flag with key "starts-ends-flag" is evaluated with default value "fallback"
@@ -38,7 +39,8 @@ Feature: flagd json evaluation
       | "abcdef" | "prefix"  |
       | "uvwxyz" | "postfix" |
       | "abcxyz" | "prefix"  |
-      | "lmnopq" | "none" |
+      | "lmnopq" | "none"    |
+      | 3        | "none"    |
 
   Scenario Outline: Semantic version operator numeric comparision
     When a string flag with key "equal-greater-lesser-version-flag" is evaluated with default value "fallback"
@@ -50,7 +52,7 @@ Feature: flagd json evaluation
       | "2.1.0"       | "greater" |
       | "1.9.0"       | "lesser"  |
       | "2.0.0-alpha" | "lesser"  |
-      | "2.0.0.0"     | "none" |
+      | "2.0.0.0"     | "none"    |
 
   Scenario Outline: Semantic version operator semantic comparision
     When a string flag with key "major-minor-version-flag" is evaluated with default value "fallback"
@@ -61,3 +63,12 @@ Feature: flagd json evaluation
       | "3.0.1" | "minor" |
       | "3.1.0" | "major" |
       | "4.0.0" | "none"  |
+
+  Scenario Outline: Errors and edge cases
+    When an integer flag with key <key> is evaluated with default value 13
+    Then the returned value should be <value>
+    Examples:
+      | key                                 | value |
+      | "error-targeting-flag"              | 2     |
+      | "missing-variant-targeting-flag"    | 2     |
+      | "non-string-variant-targeting-flag" | 2     |

--- a/gherkin/flagd-json-evaluator.feature
+++ b/gherkin/flagd-json-evaluator.feature
@@ -65,10 +65,11 @@ Feature: flagd json evaluation
       | "4.0.0" | "none"  |
 
   Scenario Outline: Errors and edge cases
-    When an integer flag with key <key> is evaluated with default value 13
+    When an integer flag with key <key> is evaluated with default value 3
     Then the returned value should be <value>
     Examples:
       | key                                 | value |
-      | "error-targeting-flag"              | 2     |
-      | "missing-variant-targeting-flag"    | 2     |
+      | "targeting-null-variant-flag"       | 2     |
+      | "error-targeting-flag"              | 3     |
+      | "missing-variant-targeting-flag"    | 3     |
       | "non-string-variant-targeting-flag" | 2     |

--- a/gherkin/flagd-json-evaluator.feature
+++ b/gherkin/flagd-json-evaluator.feature
@@ -64,6 +64,15 @@ Feature: flagd json evaluation
       | "3.1.0" | "major" |
       | "4.0.0" | "none"  |
 
+  Scenario Outline: Time-based operations
+    When an integer flag with key "timestamp-flag" is evaluated with default value 0
+    And a context containing a key "time", with value <time>
+    Then the returned value should be <value>
+    Examples:
+      | time       | value |
+      | 1          | -1    |
+      | 4133980802 | 1     |
+
   Scenario Outline: Errors and edge cases
     When an integer flag with key <key> is evaluated with default value 3
     Then the returned value should be <value>

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -18,4 +18,5 @@ ENTRYPOINT ["sh", "change-flag-wrapper.sh", "./sync", "start", \
     "-f", "changing-flag.json", \
     "-f", "custom-ops.json", \
     "-f", "evaluator-refs.json", \
+    "-f", "error-flags.json", \
     "-f", "zero-flags.json"]

--- a/sync/Dockerfile
+++ b/sync/Dockerfile
@@ -18,5 +18,5 @@ ENTRYPOINT ["sh", "change-flag-wrapper.sh", "./sync", "start", \
     "-f", "changing-flag.json", \
     "-f", "custom-ops.json", \
     "-f", "evaluator-refs.json", \
-    "-f", "error-flags.json", \
+    "-f", "edge-case-flags.json", \
     "-f", "zero-flags.json"]


### PR DESCRIPTION
This PR adds tests for a few flagd configuration edge-cases:

- targeting rule returns `null` should fall through to `defaultVariant` and return reason `DEFAULT`
- invalid/erroneous JSON logic (should error, and cause use of application (SDK) default)
- targeting returns a variant which is not in variant definition (should error, and cause use of application (SDK)  default)
- invalid sem_ver, fractional, and string-cmp inputs (should return null/false)
- non-string variants returned from the targeting rule
- timestamps

Fixes: https://github.com/open-feature/flagd-testbed/issues/84
Fixes: https://github.com/open-feature/flagd-testbed/issues/74
Relates to: https://github.com/open-feature/flagd/pull/1041