### PR TITLE
feat!: use new proto, add metadata

### DIFF
--- a/sync/README.md
+++ b/sync/README.md
@@ -50,12 +50,17 @@ Test the sync from the command line with [grpcurl](https://github.com/fullstoryd
 
 ```shell
 # request all flags
-grpcurl -import-path '/path/to/proto/dir' -proto sync.proto -plaintext localhost:9090 sync.v1.FlagSyncService/FetchAllFlags
+grpcurl -import-path '/path/to/proto/dir' -proto sync.proto -plaintext localhost:9090 flagd.sync.v1.FlagSyncService/FetchAllFlags
 ```
 
 ```shell
 # open a stream for getting flag changes
-grpcurl -import-path '/path/to/proto/dir' -proto sync.proto -plaintext localhost:9090 sync.v1.FlagSyncService/SyncFlags
+grpcurl -import-path '/path/to/proto/dir' -proto sync.proto -plaintext localhost:9090 flagd.sync.v1.FlagSyncService/SyncFlags
+```
+
+```shell
+# get metadata
+grpcurl -import-path '/path/to/proto/dir' -proto sync.proto -plaintext localhost:9090 flagd.sync.v1.FlagSyncService/GetMetadata
 ```
 
 ### Generate certificates ? 


### PR DESCRIPTION
- implements new proto: `flagd.sync.v1`
- removes old proto `sync.v1` (breaking)
- adds `metadata`