### PR TITLE
feat: provider unavailable, targeting key tests

### DIFF
--- a/flags/testing-flags.json
+++ b/flags/testing-flags.json
@@ -134,6 +134,23 @@
         "two": "dos"
       },
       "defaultVariant": "one"
+    },
+    "targeting-key-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "miss": "miss",
+        "hit": "hit"
+      },
+      "defaultVariant": "miss",
+      "targeting": {
+        "if": [
+          {
+            "==": [ { "var": "targetingKey" }, "5c3d8535-f81a-4478-a6d3-afaa4d51199e" ]
+          },
+          "hit",
+          null
+        ]
+      }
     }
   }
 }

--- a/gherkin/flagd-json-evaluator.feature
+++ b/gherkin/flagd-json-evaluator.feature
@@ -73,6 +73,16 @@ Feature: flagd json evaluation
       | 1          | -1    |
       | 4133980802 | 1     |
 
+  Scenario Outline: Targeting by targeting key
+    When a string flag with key "targeting-key-flag" is evaluated with default value "fallback"
+    And a context containing a targeting key with value <targeting key>
+    Then the returned value should be <value>
+    Then the returned reason should be <reason>
+    Examples:
+      | targeting key                          | value  | reason            |
+      | "5c3d8535-f81a-4478-a6d3-afaa4d51199e" | "hit"  | "TARGETING_MATCH" |
+      | "f20bd32d-703b-48b6-bc8e-79d53c85134a" | "miss" | "DEFAULT"         |
+
   Scenario Outline: Errors and edge cases
     When an integer flag with key <key> is evaluated with default value 3
     Then the returned value should be <value>

--- a/gherkin/flagd-reconnect.feature
+++ b/gherkin/flagd-reconnect.feature
@@ -1,4 +1,4 @@
-Feature: flagd provider reconnect functionality
+Feature: flagd provider disconnect and reconnect functionality
 
   # This test suite tests the reconnection functionality of flagd providers
 
@@ -8,3 +8,8 @@ Feature: flagd provider reconnect functionality
     Then the PROVIDER_READY handler must run when the provider connects
     And the PROVIDER_ERROR handler must run when the provider's connection is lost
     And when the connection is reestablished the PROVIDER_READY handler must run again
+
+  Scenario: Provider unavailable
+    Given flagd is unavailable
+    When a flagd provider is set and initialization is awaited
+    Then an error should be indicated within the configured deadline


### PR DESCRIPTION
Small test for consistency of all flagd providers regarding startup errors.

This works in the java contribs once https://github.com/open-feature/java-sdk/pull/794 is merged.

It should eventually be implemented everywhere.