### PR TITLE
feat: fractional non-percentage and shorthand

### DIFF
--- a/flags/custom-ops.json
+++ b/flags/custom-ops.json
@@ -23,6 +23,21 @@
         ]
       }
     },
+    "fractional-flag-shorthand": {
+      "state": "ENABLED",
+      "variants": {
+        "heads": "heads",
+        "tails": "tails",
+        "draw": "draw"
+      },
+      "defaultVariant": "draw",
+      "targeting": {
+        "fractional": [
+          [ "heads" ],
+          [ "tails", 1 ]
+        ]
+      }
+    },
     "fractional-flag-A-shared-seed": {
       "state": "ENABLED",
       "variants": {

--- a/gherkin/flagd-json-evaluator.feature
+++ b/gherkin/flagd-json-evaluator.feature
@@ -30,6 +30,15 @@ Feature: flagd json evaluation
       | "nine"  | "hearts"   |
       | 3       | "diamonds" |
 
+  Scenario Outline: Fractional operator shorthand
+    When a string flag with key "fractional-flag-shorthand" is evaluated with default value "fallback"
+    And a context containing a targeting key with value <targeting key>
+    Then the returned value should be <value>
+    Examples:
+      | targeting key      | value   |
+      | "jane@company.com" | "heads" |
+      | "joe@company.com"  | "tails" |
+
   Scenario Outline: Fractional operator with shared seed
     When a string flag with key "fractional-flag-A-shared-seed" is evaluated with default value "fallback"
     And a context containing a nested property with outer key "user" and inner key "name", with value <name>
@@ -46,7 +55,7 @@ Feature: flagd json evaluation
     And a context containing a nested property with outer key "user" and inner key "name", with value <name>
     Then the returned value should be <value>
     Examples:
-      | name    | value |
+      | name    | value             |
       | "jack"  | "ace-of-hearts"   |
       | "queen" | "ace-of-spades"   |
       | "ten"   | "ace-of-hearts"   |


### PR DESCRIPTION
Adds a new fractional test and assertions. These don't require any new test implementation in consumers since they use existing clauses/bindings.

The new flag tests:

- new, non-percentage weighting
- defaulting to `1` if no weight is passed
- default bucketing based on targeting key

I tested this locally with Java and it passes both RPC and in-process.