### PR TITLE
fix: correct assertions for shorthand targeting

### DIFF
--- a/gherkin/flagd-json-evaluator.feature
+++ b/gherkin/flagd-json-evaluator.feature
@@ -36,8 +36,8 @@ Feature: flagd json evaluation
     Then the returned value should be <value>
     Examples:
       | targeting key      | value   |
-      | "jane@company.com" | "heads" |
-      | "joe@company.com"  | "tails" |
+      | "jon@company.com"  | "heads" |
+      | "jane@company.com" | "tails" |
 
   Scenario Outline: Fractional operator with shared seed
     When a string flag with key "fractional-flag-A-shared-seed" is evaluated with default value "fallback"


### PR DESCRIPTION
When I first wrote these assertions, I had incorrectly setup the cuke bindings in the JS repo where I tested it; I was setting the targeting key to `"jon@company.com"` (including the quotes!!!) which obviously resulted in a different assignment. Then when I started implementing these tests in other repos, nothing worked :sweat_smile: 

These are the actual correct responses, which you can test in flagd:

```shell
curl -X POST "http://localhost:8013/flagd.evaluation.v1.Service/ResolveString"       -d '{"flagKey":"fractional-flag-shorthand","context":{"targetingKey":"jane@company.com"}}' -H "Content-Type: application/json"

// {"value":"tails","reason":"TARGETING_MATCH","variant":"tails","metadata":{}}
```

```shell
curl -X POST "http://localhost:8013/flagd.evaluation.v1.Service/ResolveString"       -d '{"flagKey":"fractional-flag-shorthand","context":{"targetingKey":"jon@company.com"}}' -H "Content-Type: application/json"

// {"value":"heads","reason":"TARGETING_MATCH","variant":"heads","metadata":{}}
```