### PR TITLE
feat: add Gherking file for config

### DIFF
--- a/gherkin/config.feature
+++ b/gherkin/config.feature
@@ -1,0 +1,189 @@
+Feature: Configuration Test
+
+  @rpc @in-process
+  Scenario Outline: Default Config
+    When we initialize a config
+    Then the option "<option>" of type "<type>" should have the value "<default>"
+    Examples: Basic
+      | option       | type         | default   |
+      | resolverType | ResolverType | rpc       |
+      | host         | String       | localhost |
+      | port         | Integer      | 8013      |
+      | tls          | Boolean      | false     |
+      | deadline     | Integer      | 500       |
+    @customCert
+    Examples: Certificates
+      | option   | type   | default |
+      | certPath | String | null    |
+    @unixsocket
+    Examples: Unixsocket
+      | option     | type   | default |
+      | socketPath | String | null    |
+    @events
+    Examples: Events
+      | option           | type    | default |
+      | streamDeadlineMs | Integer | 600000  |
+      | keepAlive        | Long    | 0       |
+      | retryBackoffMs   | Integer | 1000    |
+    @sync
+    Examples: Sync
+      | option           | type    | default |
+      | streamDeadlineMs | Integer | 600000  |
+      | keepAlive        | Long    | 0       |
+      | retryBackoffMs   | Integer | 1000    |
+      | selector         | String  | null    |
+    @caching
+    Examples: caching
+      | option       | type      | default |
+      | cacheType    | CacheType | lru     |
+      | maxCacheSize | Integer   | 1000    |
+    @offline
+    Examples: offline
+      | option                | type   | default |
+      | offlineFlagSourcePath | String | null    |
+
+  @rpc
+  Scenario Outline: Default Config RPC
+    When we initialize a config for "rpc"
+    Then the option "<option>" of type "<type>" should have the value "<default>"
+    Examples:
+      | option | type    | default |
+      | port   | Integer | 8013    |
+
+  @in-process
+  Scenario Outline: Default Config In-Process
+    When we initialize a config for "in-process"
+    Then the option "<option>" of type "<type>" should have the value "<default>"
+    Examples:
+      | option | type    | default |
+      | port   | Integer | 8015    |
+
+  Scenario Outline: Dedicated Config
+    When we have an option "<option>" of type "<type>" with value "<value>"
+    And we initialize a config
+    Then the option "<option>" of type "<type>" should have the value "<value>"
+    Examples:
+      | option       | type         | value      |
+      | resolverType | ResolverType | in-process |
+      | host         | String       | local      |
+      | tls          | Boolean      | True       |
+      | port         | Integer      | 1234       |
+      | deadline     | Integer      | 123        |
+    @customCert
+    Examples:
+      | option   | type   | value |
+      | certPath | String | path  |
+    @unixsocket
+    Examples:
+      | option     | type   | value |
+      | socketPath | String | path  |
+    @events
+    Examples:
+      | option           | type    | value  |
+      | streamDeadlineMs | Integer | 500000 |
+      | keepAlive        | Long    | 5      |
+      | retryBackoffMs   | Integer | 5000   |
+    @sync
+    Examples:
+      | option           | type    | value    |
+      | streamDeadlineMs | Integer | 500000   |
+      | keepAlive        | Long    | 5        |
+      | retryBackoffMs   | Integer | 5000     |
+      | selector         | String  | selector |
+    @caching
+    Examples:
+      | option       | type      | value    |
+      | cacheType    | CacheType | disabled |
+      | maxCacheSize | Integer   | 1236     |
+    @offline
+    Examples:
+      | option                | type   | value |
+      | offlineFlagSourcePath | String | path  |
+
+  Scenario Outline: Dedicated Config via Env_var
+    When we have an environment variable "<env>" with value "<value>"
+    And we initialize a config
+    Then the option "<option>" of type "<type>" should have the value "<value>"
+    Examples:
+      | option       | env               | type         | value      |
+      | resolverType | FLAGD_RESOLVER    | ResolverType | in-process |
+      | resolverType | FLAGD_RESOLVER    | ResolverType | IN-PROCESS |
+      | resolverType | FLAGD_RESOLVER    | ResolverType | rpc        |
+      | resolverType | FLAGD_RESOLVER    | ResolverType | RPC        |
+      | host         | FLAGD_HOST        | String       | local      |
+      | tls          | FLAGD_TLS         | Boolean      | True       |
+      | port         | FLAGD_PORT        | Integer      | 1234       |
+      | deadline     | FLAGD_DEADLINE_MS | Integer      | 123        |
+    @customCert
+    Examples:
+      | option   | env                    | type   | value |
+      | certPath | FLAGD_SERVER_CERT_PATH | String | path  |
+    @unixsocket
+    Examples:
+      | option     | env               | type   | value |
+      | socketPath | FLAGD_SOCKET_PATH | String | path  |
+    @events
+    Examples:
+      | option           | env                      | type    | value  |
+      | streamDeadlineMs | FLAGD_STREAM_DEADLINE_MS | Integer | 500000 |
+      | keepAlive        | FLAGD_KEEP_ALIVE_TIME_MS | Long    | 5      |
+      | retryBackoffMs   | FLAGD_RETRY_BACKOFF_MS   | Integer | 5000   |
+    @sync
+    Examples:
+      | option           | env                      | type    | value    |
+      | streamDeadlineMs | FLAGD_STREAM_DEADLINE_MS | Integer | 500000   |
+      | keepAlive        | FLAGD_KEEP_ALIVE_TIME_MS | Long    | 5        |
+      | retryBackoffMs   | FLAGD_RETRY_BACKOFF_MS   | Integer | 5000     |
+      | selector         | FLAGD_SOURCE_SELECTOR    | String  | selector |
+    @caching
+    Examples:
+      | option       | env                  | type      | value    |
+      | cacheType    | FLAGD_CACHE          | CacheType | disabled |
+      | maxCacheSize | FLAGD_MAX_CACHE_SIZE | Integer   | 1236     |
+    @offline
+    Examples:
+      | option                | env                            | type   | value |
+      | offlineFlagSourcePath | FLAGD_OFFLINE_FLAG_SOURCE_PATH | String | path  |
+
+  Scenario Outline: Dedicated Config via Env_var and set
+    When we have an environment variable "<env>" with value "<env-value>"
+    And we have an option "<option>" of type "<type>" with value "<value>"
+    And we initialize a config
+    Then the option "<option>" of type "<type>" should have the value "<value>"
+    Examples:
+      | option       | env               | type         | value      | env-value |
+      | resolverType | FLAGD_RESOLVER    | ResolverType | in-process | rpc       |
+      | host         | FLAGD_HOST        | String       | local      | l         |
+      | tls          | FLAGD_TLS         | Boolean      | True       | False     |
+      | port         | FLAGD_PORT        | Integer      | 1234       | 3456      |
+      | deadline     | FLAGD_DEADLINE_MS | Integer      | 123        | 345       |
+    @customCert
+    Examples:
+      | option   | env                    | type   | value | env-value |
+      | certPath | FLAGD_SERVER_CERT_PATH | String | path  | rpc       |
+    @unixsocket
+    Examples:
+      | option     | env               | type   | value | env-value |
+      | socketPath | FLAGD_SOCKET_PATH | String | path  | rpc       |
+    @events
+    Examples:
+      | option           | env                      | type    | value  | env-value |
+      | streamDeadlineMs | FLAGD_STREAM_DEADLINE_MS | Integer | 500000 | 400       |
+      | keepAlive        | FLAGD_KEEP_ALIVE_TIME_MS | Long    | 5      | 4         |
+      | retryBackoffMs   | FLAGD_RETRY_BACKOFF_MS   | Integer | 5000   | 400       |
+    @sync
+    Examples:
+      | option           | env                      | type    | value  | env-value |
+      | streamDeadlineMs | FLAGD_STREAM_DEADLINE_MS | Integer | 500000 | 400       |
+      | keepAlive        | FLAGD_KEEP_ALIVE_TIME_MS | Long    | 5      | 4         |
+      | retryBackoffMs   | FLAGD_RETRY_BACKOFF_MS   | Integer | 5000   | 400       |
+      | selector | FLAGD_SOURCE_SELECTOR | String | selector | sele      |
+    @caching
+    Examples:
+      | option       | env                  | type      | value    | env-value |
+      | cacheType    | FLAGD_CACHE          | CacheType | disabled | lru       |
+      | maxCacheSize | FLAGD_MAX_CACHE_SIZE | Integer   | 1236     | 2345      |
+    @offline
+    Examples:
+      | option                | env                            | type   | value | env-value |
+      | offlineFlagSourcePath | FLAGD_OFFLINE_FLAG_SOURCE_PATH | String | path  | lll       |


### PR DESCRIPTION
I tested this with Java and Python.
With Tags we can deactivate features.
This files is not suppose to be run in an e2e env, but as a unittest for the configuration generation

Questions:
- is java our correct implemenation? naming and type wise (why is keep alive in java a long, and everything else is a int)

java code for the whole gherkin file:
```java
package dev.openfeature.contrib.providers.flagd.e2e.steps.config;

import dev.openfeature.contrib.providers.flagd.Config;
import dev.openfeature.contrib.providers.flagd.FlagdOptions;
import dev.openfeature.contrib.providers.flagd.resolver.grpc.cache.CacheType;
import io.cucumber.java.en.Then;
import io.cucumber.java.en.When;

import java.lang.reflect.InvocationTargetException;
import java.lang.reflect.Method;
import java.util.Arrays;
import java.util.HashMap;
import java.util.Map;
import java.util.Objects;

import static org.assertj.core.api.Assertions.assertThat;

public class ConfigSteps {

    FlagdOptions.FlagdOptionsBuilder builder = FlagdOptions.builder();
    FlagdOptions options;

    @When("we initialize a config")
    public void we_initialize_a_config() {
        options = builder.build();
    }

    @When("we initialize a config for {string}")
    public void we_initialize_a_config_for(String string) {
        switch (string.toLowerCase()) {
            case "in-process":
                options = builder.resolverType(Config.Resolver.IN_PROCESS).build();
                break;
            case "rpc":
                options = builder.resolverType(Config.Resolver.RPC).build();
                break;
            default:
                throw new RuntimeException("Unknown resolver type: " + string);
        }
    }

    @When("we have an option {string} of type {string} with value {string}")
    public void we_have_an_option_of_type_with_value(String option, String type, String value) throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException {
        Object converted = convert(value, type);
        Method method = Arrays.stream(builder.getClass().getMethods())
                .filter(method1 -> method1.getName().equals(option))
                .findFirst()
                .orElseThrow(RuntimeException::new);
        method.invoke(builder, converted);
    }


    Map<String, String> envVarsSet = new HashMap<>();

    @When("we have an environment variable {string} with value {string}")
    public void we_have_an_environment_variable_with_value(String string, String string2) throws IllegalAccessException, NoSuchFieldException {
        String getenv = System.getenv(string);
        envVarsSet.put(string, getenv);
        EnvironmentVariableUtils.set(string, string2);
    }

    private Object convert(String value, String type) throws ClassNotFoundException {
        if (Objects.equals(value, "null")) return null;
        switch (type) {
            case "Boolean":
                return Boolean.parseBoolean(value);
            case "String":
                return value;
            case "Integer":
                return Integer.parseInt(value);
            case "Long":
                return Long.parseLong(value);
            case "ResolverType":
                switch (value.toLowerCase()) {
                    case "in-process":
                        return Config.Resolver.IN_PROCESS;
                    case "rpc":
                        return Config.Resolver.RPC;
                    default:
                        throw new RuntimeException("Unknown resolver type: " + value);
                }
            case "CacheType":
                return CacheType.valueOf(value.toUpperCase()).getValue();
        }
        throw new RuntimeException("Unknown config type: " + type);
    }

    @Then("the option {string} of type {string} should have the value {string}")
    public void the_option_of_type_should_have_the_value(String option, String type, String value) throws Throwable {
        Object convert = convert(value, type);

        assertThat(options).hasFieldOrPropertyWithValue(option, convert);

        // Resetting env vars
        for (Map.Entry<String, String> envVar : envVarsSet.entrySet()) {
            if (envVar.getValue() == null) {
                EnvironmentVariableUtils.clear(envVar.getKey());
            } else {
                EnvironmentVariableUtils.set(envVar.getKey(), envVar.getValue());
            }
        }
    }
}

```