### PR TITLE
build(renovate): Utilize default OpenFeature Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["github>open-feature/community-tooling"],
   "semanticCommitType": "feat",
   "regexManagers": [
     {


### PR DESCRIPTION
We do have a default OpenFeature Renovate configuration within our community-tooling repository. (https://github.com/open-feature/community-tooling/blob/main/renovate.json)

To reduce maintenance efforts, we should stick to the general one as a basis.
