### PR TITLE
feat: Context value hydration via flagd

### DIFF
--- a/flags/metadata-flags.json
+++ b/flags/metadata-flags.json
@@ -1,0 +1,28 @@
+{
+  "flags": {
+    "flagd-context-aware": {
+      "state": "ENABLED",
+      "variants": {
+        "internal": "INTERNAL",
+        "external": "EXTERNAL"
+      },
+      "defaultVariant": "external",
+      "targeting": {
+        "if": [
+          {
+            "==": [
+              {
+                "var": [
+                  "injectedMetadata"
+                ]
+              },
+              "set"
+            ]
+          },
+          "internal",
+          "external"
+        ]
+      }
+    }
+  }
+}

--- a/gherkin/targeting.feature
+++ b/gherkin/targeting.feature
@@ -144,3 +144,9 @@ Feature: Targeting rules
       | missing-variant-targeting-flag    | 3     |
       | non-string-variant-targeting-flag | 2     |
       | empty-targeting-flag              | 1     |
+
+  @flagdcontext
+  Scenario: Use Flagd provided context
+    Given a String-flag with key "flagd-context-aware" and a default value "not"
+    When the flag was evaluated with details
+    Then the resolved details value should be "INTERNAL"

--- a/launchpad/configs/default.json
+++ b/launchpad/configs/default.json
@@ -8,5 +8,8 @@
       "uri": "rawflags/selector-flags.json",
       "provider": "file"
     }
-  ]
+  ],
+  "context-value": {
+    "injectedMetadata": "set"
+  }
 }

--- a/launchpad/configs/ssl.json
+++ b/launchpad/configs/ssl.json
@@ -10,5 +10,8 @@
       "uri": "rawflags/selector-flags.json",
       "provider": "file"
     }
-  ]
+  ],
+  "context-value": {
+    "flagd-testbed": "set"
+  }
 }

--- a/launchpad/configs/ssl.json
+++ b/launchpad/configs/ssl.json
@@ -12,6 +12,6 @@
     }
   ],
   "context-value": {
-    "flagd-testbed": "set"
+    "injectedMetadata": "set"
   }
 }


### PR DESCRIPTION
With this pullrequest our flagd-testbed will provide flagd context values (`--context-value` cli option) and a gherkin test to ensure these context values are used during flag evaluation.