### PR TITLE
fix: Casesensitive messages for context hydration.

### DIFF
--- a/flags/metadata-flags.json
+++ b/flags/metadata-flags.json
@@ -13,7 +13,7 @@
             "==": [
               {
                 "var": [
-                  "injectedMetadata"
+                  "injectedmetadata"
                 ]
               },
               "set"

--- a/launchpad/configs/default.json
+++ b/launchpad/configs/default.json
@@ -10,6 +10,6 @@
     }
   ],
   "context-value": {
-    "injectedMetadata": "set"
+    "injectedmetadata": "set"
   }
 }

--- a/launchpad/configs/ssl.json
+++ b/launchpad/configs/ssl.json
@@ -12,6 +12,6 @@
     }
   ],
   "context-value": {
-    "injectedMetadata": "set"
+    "injectedmetadata": "set"
   }
 }


### PR DESCRIPTION
viper is not honoring case sensitivity on messages, hence the current configuration will not work. This pr fixes this.
