### PR TITLE
feat: add context-sensitive test with connection err

### DIFF
--- a/gherkin/targeting.feature
+++ b/gherkin/targeting.feature
@@ -146,7 +146,19 @@ Feature: Targeting rules
       | empty-targeting-flag              | 1     |
 
   @flagdcontext
-  Scenario: Use Flagd provided context
+  Scenario: Use injected context
     Given a String-flag with key "flagd-context-aware" and a default value "not"
+    When the flag was evaluated with details
+    Then the resolved details value should be "INTERNAL"
+
+    
+  @flagdcontext
+  Scenario: Use injected context after connection error
+    Given a String-flag with key "flagd-context-aware" and a default value "not"
+    And a stale event handler
+    When the flag was evaluated with details
+    Then the resolved details value should be "INTERNAL"
+    When the connection is lost for 6s
+    And a stale event was fired
     When the flag was evaluated with details
     Then the resolved details value should be "INTERNAL"

--- a/gherkin/targeting.feature
+++ b/gherkin/targeting.feature
@@ -151,7 +151,6 @@ Feature: Targeting rules
     When the flag was evaluated with details
     Then the resolved details value should be "INTERNAL"
 
-
   @contextEnrichment
   Scenario: Use enriched context on connection error
     Given a String-flag with key "flagd-context-aware" and a default value "not"

--- a/gherkin/targeting.feature
+++ b/gherkin/targeting.feature
@@ -145,15 +145,15 @@ Feature: Targeting rules
       | non-string-variant-targeting-flag | 2     |
       | empty-targeting-flag              | 1     |
 
-  @flagdcontext
-  Scenario: Use injected context
+  @contextEnrichment
+  Scenario: Use enriched context
     Given a String-flag with key "flagd-context-aware" and a default value "not"
     When the flag was evaluated with details
     Then the resolved details value should be "INTERNAL"
 
-    
-  @flagdcontext
-  Scenario: Use injected context after connection error
+
+  @contextEnrichment
+  Scenario: Use enriched context on connection error
     Given a String-flag with key "flagd-context-aware" and a default value "not"
     And a stale event handler
     When the flag was evaluated with details


### PR DESCRIPTION
Adds a test for asserting the injected context still works after connection error/stale events.