### PR TITLE
feat: Add testcases for targeted zero values

### DIFF
--- a/flags/zero-flags.json
+++ b/flags/zero-flags.json
@@ -31,6 +31,70 @@
         "non-zero": 1.0
       },
       "defaultVariant": "zero"
+    },
+    "boolean-targeted-zero-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "zero": false,
+        "non-zero": true
+      },
+      "targeting": {
+        "if": [
+          {
+            "$ref": "is_ballmer"
+          },
+          "zero"
+        ]
+      },
+      "defaultVariant": "zero"
+    },
+    "string-targeted-zero-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "zero": "",
+        "non-zero": "str"
+      },
+      "targeting": {
+        "if": [
+          {
+            "$ref": "is_ballmer"
+          },
+          "zero"
+        ]
+      },
+      "defaultVariant": "zero"
+    },
+    "integer-targeted-zero-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "zero": 0,
+        "non-zero": 1
+      },
+      "targeting": {
+        "if": [
+          {
+            "$ref": "is_ballmer"
+          },
+          "zero"
+        ]
+      },
+      "defaultVariant": "zero"
+    },
+    "float-targeted-zero-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "zero": 0.0,
+        "non-zero": 1.0
+      },
+      "targeting": {
+        "if": [
+          {
+            "$ref": "is_ballmer"
+          },
+          "zero"
+        ]
+      },
+      "defaultVariant": "zero"
     }
   }
 }

--- a/gherkin/evaluation.feature
+++ b/gherkin/evaluation.feature
@@ -25,6 +25,7 @@ Feature: flagd evaluations
     Given a <type>-flag with key "<key>" and a default value "<default>"
     When the flag was evaluated with details
     Then the resolved details value should be "<resolved_value>"
+    And the reason should be "STATIC"
 
     Examples:
       | key               | type    | default | resolved_value |
@@ -32,3 +33,33 @@ Feature: flagd evaluations
       | string-zero-flag  | String  | hi      |                |
       | integer-zero-flag | Integer | 1       | 0              |
       | float-zero-flag   | Float   | 0.1     | 0.0            |
+
+  @targeting
+  Scenario Outline: Resolves zero value with targeting
+    Given a <type>-flag with key "<key>" and a default value "<default>"
+    And a context containing a key "email", with type "String" and with value "ballmer@macrosoft.com"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<resolved_value>"
+    And the reason should be "TARGETING_MATCH"
+
+    Examples:
+      | key                        | type    | default | resolved_value |
+      | boolean-targeted-zero-flag | Boolean | true    | false          |
+      | string-targeted-zero-flag  | String  | hi      |                |
+      | integer-targeted-zero-flag | Integer | 1       | 0              |
+      | float-targeted-zero-flag   | Float   | 0.1     | 0.0            |
+
+  @targeting
+  Scenario Outline: Resolves zero value with targeting using default
+    Given a <type>-flag with key "<key>" and a default value "<default>"
+    And a context containing a key "email", with type "String" and with value "ballmer@none.com"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<resolved_value>"
+    And the reason should be "DEFAULT"
+
+    Examples:
+      | key                        | type    | default | resolved_value |
+      | boolean-targeted-zero-flag | Boolean | true    | false          |
+      | string-targeted-zero-flag  | String  | hi      |                |
+      | integer-targeted-zero-flag | Integer | 1       | 0              |
+      | float-targeted-zero-flag   | Float   | 0.1     | 0.0            |


### PR DESCRIPTION
As discovered within https://github.com/open-feature/python-sdk-contrib/issues/213 we do not have testcases covering zero values and targeting.

This pull request extends our zero value tests with some targeted rules, and helps us to detect this issues earlier.

relates: https://github.com/open-feature/python-sdk-contrib/issues/213
