### PR TITLE
fix: make flag keys unique as a workaround for selector issue

### DIFF
--- a/flags/selector-flag-combined-metadata.json
+++ b/flags/selector-flag-combined-metadata.json
@@ -1,6 +1,6 @@
 {
   "flags": {
-    "metadata-flag": {
+    "combined-metadata-flag": {
       "state": "ENABLED",
       "variants": {
         "true": true,

--- a/flags/selector-flag-set-metadata.json
+++ b/flags/selector-flag-set-metadata.json
@@ -1,6 +1,6 @@
 {
   "flags": {
-    "metadata-flag": {
+    "set-metadata-flag": {
       "state": "ENABLED",
       "variants": {
         "true": true,

--- a/gherkin/metadata.feature
+++ b/gherkin/metadata.feature
@@ -20,7 +20,7 @@ Feature: flag and flag set metadata
   Scenario: Returns flag set metadata
     Given an option "selector" of type "String" with value "rawflags/selector-flag-set-metadata.json"
     And a stable flagd provider
-    And a Boolean-flag with key "metadata-flag" and a default value "true"
+    And a Boolean-flag with key "set-metadata-flag" and a default value "true"
     When the flag was evaluated with details
     Then the resolved metadata should contain
       | key     | metadata_type | value |
@@ -32,7 +32,7 @@ Feature: flag and flag set metadata
   Scenario: Flag metadata overwrites flag set metadata
     Given an option "selector" of type "String" with value "rawflags/selector-flag-combined-metadata.json"
     And a stable flagd provider
-    And a Boolean-flag with key "metadata-flag" and a default value "true"
+    And a Boolean-flag with key "combined-metadata-flag" and a default value "true"
     When the flag was evaluated with details
     Then the resolved metadata should contain
       | key              | metadata_type | value |


### PR DESCRIPTION
## This PR
Makes the flag keys of feature flags unique to work around a selector issue where the last flag with a key overwrites all other flags with the same key, even when using different selectors (https://github.com/open-feature/flagd/issues/1596)

### Related Issues

Workaround for https://github.com/open-feature/flagd/issues/1596 to fix https://github.com/open-feature/python-sdk-contrib/issues/119

