### PR TITLE
fix: reintroduce change flag request and increase test stability

### DIFF
--- a/gherkin/connection.feature
+++ b/gherkin/connection.feature
@@ -30,7 +30,7 @@ Feature: flagd provider disconnect and reconnect functionality
     And a ready event handler
     And a error event handler
     When a ready event was fired
-    When the connection is lost for 3s
+    When the connection is lost for 5s
     Then the error event handler should have been executed
     Then the ready event handler should have been executed
 

--- a/launchpad/handlers/http.go
+++ b/launchpad/handlers/http.go
@@ -71,8 +71,6 @@ func ChangeHandler(w http.ResponseWriter, r *http.Request) {
 	mu.Lock()
 	defer mu.Unlock()
 
-	println("receiveing request")
-
 	// Path to the configuration file
 	configFile := "rawflags/changing-flag.json"
 
@@ -91,7 +89,6 @@ func ChangeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Find the "changing-flag" and toggle the default variant
-
 	flag, exists := config.Flags["changing-flag"]
 	if !exists {
 		http.Error(w, "Flag 'changing-flag' not found in the configuration", http.StatusNotFound)
@@ -99,7 +96,6 @@ func ChangeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Toggle the defaultVariant between "foo" and "bar"
-
 	if flag.DefaultVariant == "foo" {
 		flag.DefaultVariant = "bar"
 	} else {
@@ -115,6 +111,7 @@ func ChangeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// the file watcher should be triggered instantly. If not, we add a timeout to prevent a hanging test
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -135,8 +132,6 @@ func ChangeHandler(w http.ResponseWriter, r *http.Request) {
 
 	select {
 	case <-ctx.Done():
-		fmt.Printf("ctx done %v \n", ctx)
-		fmt.Printf("ctx done err %v \n", ctx.Err())
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			http.Error(w, fmt.Sprintf("Flags were not updated in time: %v", ctx.Err()), http.StatusInternalServerError)
 		} else {

--- a/launchpad/pkg/filewatcher.go
+++ b/launchpad/pkg/filewatcher.go
@@ -24,8 +24,7 @@ func StartFileWatcher() error {
 					return
 				}
 				if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove) != 0 {
-					fmt.Println("File watcher event:", event.Name)
-					fmt.Println("Config changed, regenerating JSON...")
+					fmt.Printf("%v config changed, regenerating JSON...\n", event.Name)
 					if err := CombineJSONFiles(InputDir); err != nil {
 						fmt.Printf("Error combining JSON files: %v\n", err)
 					}

--- a/launchpad/pkg/filewatcher.go
+++ b/launchpad/pkg/filewatcher.go
@@ -3,7 +3,11 @@ package flagd
 import (
 	"fmt"
 	"github.com/fsnotify/fsnotify"
+	"strings"
+	"sync"
 )
+
+var changeFlagLock sync.Mutex
 
 func StartFileWatcher() error {
 	watcher, err := fsnotify.NewWatcher()
@@ -20,9 +24,18 @@ func StartFileWatcher() error {
 					return
 				}
 				if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove) != 0 {
+					fmt.Println("File watcher event:", event.Name)
 					fmt.Println("Config changed, regenerating JSON...")
 					if err := CombineJSONFiles(InputDir); err != nil {
 						fmt.Printf("Error combining JSON files: %v\n", err)
+					}
+					if strings.HasSuffix(event.Name, "changing-flag.json") {
+						changeFlagLock.Lock()
+						for _, v := range changeFlagUpdateListeners {
+							v.Done()
+						}
+						changeFlagUpdateListeners = nil
+						changeFlagLock.Unlock()
 					}
 				}
 			case err, ok := <-watcher.Errors:
@@ -40,4 +53,15 @@ func StartFileWatcher() error {
 
 	fmt.Println("File watcher started.")
 	return nil
+}
+
+var changeFlagUpdateListeners []*sync.WaitGroup
+
+// RegisterWaitForNextChangingFlagUpdate
+// The waitGroup passed to this function will be invoked when a file update to the changing-flag.json file is detected.
+// After such an invocation, it will be removed and will not be called on subsequent updates to the	file.
+func RegisterWaitForNextChangingFlagUpdate(waitGroup *sync.WaitGroup) {
+	changeFlagLock.Lock()
+	defer changeFlagLock.Unlock()
+	changeFlagUpdateListeners = append(changeFlagUpdateListeners, waitGroup)
 }


### PR DESCRIPTION
## This PR
Reintroduces the code to change a feature flag when the change endpoint is called. Increases test stability.

