### PR TITLE
fix: change object return value to double

### DIFF
--- a/gherkin/rpc-caching.feature
+++ b/gherkin/rpc-caching.feature
@@ -23,7 +23,7 @@ Feature: Flag evaluation with Caching
       | string-flag  | String  | bye     | greeting         | hi                                                                            |
       | integer-flag | Integer | 1       | ten              | 10                                                                            |
       | float-flag   | Float   | 0.1     | half             | 0.5                                                                           |
-      | object-flag  | Object  | {}      | template         | {"showImages": true, "title": "Check out these pics!", "imagesPerPage": 100 } |
+      | object-flag  | Object  | {}      | template         | {"showImages": true, "title": "Check out these pics!", "imagesPerPage": 100.0 } |
 
   Scenario: Flag change event with caching
     Given a String-flag with key "changing-flag" and a default value "false"


### PR DESCRIPTION
Within certain implementations, we just use a mapper to convert this JSON property, e.g. Java. But this will be mapped to an integer rather than a double, invalidating our comparison checks.

This is a quick fix to make our builds pass again.

see: https://github.com/open-feature/java-sdk-contrib/issues/1307


