### PR TITLE
feat: add tests for no defaultVariant

### DIFF
--- a/flags/testing-flags.json
+++ b/flags/testing-flags.json
@@ -164,10 +164,10 @@
       "state": "ENABLED",
       "variants": {
         "small": 10,
-        "off": 1000
+        "big": 1000
       }
     },
-    "no-default-flag-with-targeting": {
+    "no-default-flag-null-targeting-variant": {
       "state": "ENABLED",
       "variants": {
         "normal": "CFO",
@@ -185,6 +185,26 @@
           },
           "special",
           null
+        ]
+      }
+    },
+    "no-default-flag-undefined-targeting-variant": {
+      "state": "ENABLED",
+      "variants": {
+        "normal": "CFO",
+        "special": "CEO"
+      },
+      "targeting": {
+        "if": [
+          {
+            "==": [
+              "jobs@orange.com",
+              {
+                "var": ["email"]
+              }
+            ]
+          },
+          "special"
         ]
       }
     }

--- a/flags/testing-flags.json
+++ b/flags/testing-flags.json
@@ -151,6 +151,42 @@
           null
         ]
       }
+    },
+    "null-default-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": null
+    },
+    "undefined-default-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "small": 10,
+        "off": 1000
+      }
+    },
+    "no-default-flag-with-targeting": {
+      "state": "ENABLED",
+      "variants": {
+        "normal": "CFO",
+        "special": "CEO"
+      },
+      "targeting": {
+        "if": [
+          {
+            "==": [
+              "jobs@orange.com",
+              {
+                "var": ["email"]
+              }
+            ]
+          },
+          "special",
+          null
+        ]
+      }
     }
   }
 }

--- a/gherkin/evaluation.feature
+++ b/gherkin/evaluation.feature
@@ -63,3 +63,23 @@ Feature: flagd evaluations
       | string-targeted-zero-flag  | String  | hi      |                |
       | integer-targeted-zero-flag | Integer | 1       | 0              |
       | float-targeted-zero-flag   | Float   | 0.1     | 0.0            |
+
+  @no-default
+  Scenario Outline: Resolves flag with no defaultValue correctly
+    Given a <type>-flag with key "<key>" and a default value "<default>"
+    And a context containing a key "email", with type "String" and with value "<email>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<resolved_value>"
+    And the reason should be "<reason>"
+    And the error-code should be "<error_code>"
+
+    # For now, no defaultValue is resolved as FLAG_NOT_FOUND to result in a code default.
+    # This may be handled more gracefully in the future.
+    Examples:
+      | key                            | type    | email              | default  | resolved_value | reason          | error_code     |
+      | null-default-flag              | Boolean |                    | true     | true           | ERROR           | FLAG_NOT_FOUND |
+      | null-default-flag              | Boolean |                    | false    | false          | ERROR           | FLAG_NOT_FOUND |
+      | undefined-default-flag         | Integer |                    |      100 |            100 | ERROR           | FLAG_NOT_FOUND |
+      | no-default-flag-with-targeting | String  | wozniak@orange.com | Inventor | Inventor       | ERROR           | FLAG_NOT_FOUND |
+      | no-default-flag-with-targeting | String  | wozniak@orange.com | Founder  | Founder        | ERROR           | FLAG_NOT_FOUND |
+      | no-default-flag-with-targeting | String  | jobs@orange.com    | CEO      | CEO            | TARGETING_MATCH |                |

--- a/gherkin/evaluation.feature
+++ b/gherkin/evaluation.feature
@@ -76,10 +76,11 @@ Feature: flagd evaluations
     # For now, no defaultValue is resolved as FLAG_NOT_FOUND to result in a code default.
     # This may be handled more gracefully in the future.
     Examples:
-      | key                            | type    | email              | default  | resolved_value | reason          | error_code     |
-      | null-default-flag              | Boolean |                    | true     | true           | ERROR           | FLAG_NOT_FOUND |
-      | null-default-flag              | Boolean |                    | false    | false          | ERROR           | FLAG_NOT_FOUND |
-      | undefined-default-flag         | Integer |                    |      100 |            100 | ERROR           | FLAG_NOT_FOUND |
-      | no-default-flag-with-targeting | String  | wozniak@orange.com | Inventor | Inventor       | ERROR           | FLAG_NOT_FOUND |
-      | no-default-flag-with-targeting | String  | wozniak@orange.com | Founder  | Founder        | ERROR           | FLAG_NOT_FOUND |
-      | no-default-flag-with-targeting | String  | jobs@orange.com    | CEO      | CEO            | TARGETING_MATCH |                |
+      | key                                         | type    | email              | default  | resolved_value | reason          | error_code     |
+      | null-default-flag                           | Boolean |                    | true     | true           | ERROR           | FLAG_NOT_FOUND |
+      | null-default-flag                           | Boolean |                    | false    | false          | ERROR           | FLAG_NOT_FOUND |
+      | undefined-default-flag                      | Integer |                    |      100 |            100 | ERROR           | FLAG_NOT_FOUND |
+      | no-default-flag-null-targeting-variant      | String  | wozniak@orange.com | Inventor | Inventor       | ERROR           | FLAG_NOT_FOUND |
+      | no-default-flag-null-targeting-variant      | String  | wozniak@orange.com | Founder  | Founder        | ERROR           | FLAG_NOT_FOUND |
+      | no-default-flag-null-targeting-variant      | String  | jobs@orange.com    | CEO      | CEO            | TARGETING_MATCH |                |
+      | no-default-flag-undefined-targeting-variant | String  | wozniak@orange.com | Retired  | Retired        | ERROR           | FLAG_NOT_FOUND |


### PR DESCRIPTION
Adds tests for optional `defaultVariant` to the suite. I've tested this locally with my implementation of the no-defaultVariant-support in JS, and it works as expected.

The 3 flags and 6 assertions I've added test:

- `defaultValue: null` with no `targeting` -> code default (`true` and `false`), FLAG_NOT_FOUND
- `defaultValue: undefined` with no `targeting` -> code default (string1 vs string2), FLAG_NOT_FOUND
- `defaultValue: undefined` with targeting that matches -> TARGETING_MATCH
- `defaultValue: undefined` with targeting that does not match -> code default (int), FLAG_NOT_FOUND

Resolves: https://github.com/open-feature/flagd-testbed/issues/268