### PR TITLE
feat: Add tests for temporary metadata toggle

### DIFF
--- a/gherkin/sync-payload.feature
+++ b/gherkin/sync-payload.feature
@@ -1,0 +1,28 @@
+@in-process @sync-payload
+Feature: Disabled Sync Metadata
+
+  Background:
+    Given a syncpayload flagd provider
+
+  Scenario: Use enriched context
+    Given a String-flag with key "flagd-context-aware" and a default value "not"
+    When the flag was evaluated with details
+    Then the resolved details value should be "INTERNAL"
+
+  @grace
+  Scenario: Use enriched context on connection error for IN-PROCESS
+    Given a String-flag with key "flagd-context-aware" and a default value "not"
+    And a stale event handler
+    And a ready event handler
+    When the flag was evaluated with details
+    Then the resolved details value should be "INTERNAL"
+    When the connection is lost for 6s
+    And a stale event was fired
+    When the flag was evaluated with details
+    Then the resolved details value should be "INTERNAL"
+    When a ready event was fired
+
+  Scenario: Resolve value independent of context
+    Given a Boolean-flag with key "boolean-flag" and a default value "false"
+    When the flag was evaluated with details
+    Then the resolved details value should be "true"

--- a/launchpad/configs/sync-payload.json
+++ b/launchpad/configs/sync-payload.json
@@ -1,0 +1,16 @@
+{
+  "sources": [
+    {
+      "uri": "flags/allFlags.json",
+      "provider": "file"
+    },
+    {
+      "uri": "rawflags/selector-flags.json",
+      "provider": "file"
+    }
+  ],
+  "context-value": {
+    "injectedmetadata": "set"
+  },
+  "disable-sync-metadata" : true
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds tests for the disable-sync-metadata toggle in flagd. The tests check that with the endpoint disabled, flags are still evaluated correctly.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

[#1584](https://github.com/open-feature/flagd/issues/1584)

