### PR TITLE
fix: remove file mode from forbidden flagd connection test

### DIFF
--- a/gherkin/connection.feature
+++ b/gherkin/connection.feature
@@ -50,7 +50,7 @@ Feature: flagd provider disconnect and reconnect functionality
     And a error event handler
     Then the error event handler should have been executed within 3000ms
 
-  @rpc @in-process @file @forbidden
+  @rpc @in-process @forbidden
   # This test ensures that a forbidden response from flagd results in a fatal client state
   Scenario: Provider forbidden
     Given an option "fatalStatusCodes" of type "StringList" with value "PERMISSION_DENIED"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- removes the file mode from the forbidden flagd connection test case

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

https://github.com/open-feature/go-sdk-contrib/issues/756

