### PR TITLE
fix: deadlock if /change is called during /restart

### DIFF
--- a/launchpad/main.go
+++ b/launchpad/main.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"openfeature.com/flagd-testbed/launchpad/handlers"
-	"openfeature.com/flagd-testbed/launchpad/pkg"
+	flagd "openfeature.com/flagd-testbed/launchpad/pkg"
 )
 
 func main() {
@@ -22,7 +22,7 @@ func main() {
 		log.Fatalf("Error during initial JSON combination: %v", err)
 	}
 
-	if err := flagd.StartFileWatcher(); err != nil {
+	if err := flagd.RestartFileWatcher(); err != nil {
 		log.Fatalf("Error starting file watcher: %v", err)
 	}
 

--- a/launchpad/pkg/flagd.go
+++ b/launchpad/pkg/flagd.go
@@ -27,7 +27,9 @@ func ensureStartConditions() {
 			fmt.Printf("Error combining JSON files on flagd start: %v\n", err)
 		}
 	}
-	ContinueFileWatcher()
+	if err := RestartFileWatcher(); err != nil {
+		fmt.Printf("error restarting file watcher: %v\n", err)
+	}
 }
 
 func deleteCombinedFlagsFile() {
@@ -45,7 +47,6 @@ func RestartFlagd(seconds int) {
 	ctx, cancel := context.WithCancel(context.Background())
 	restartCancelFunc = cancel
 
-	PauseFileWatcher()
 	deleteCombinedFlagsFile()
 	err := stopFlagDWithoutLock()
 	if err != nil {


### PR DESCRIPTION
If the `/change` endpoint was called while flagd was restarting (due to the `/restart` endpoint) the filewatcher was closed (because the `allFlags.json` was deleted). Due to this, the waitgroup never stopped waiting.

In the Java e2e suite, it looks like this:

```sh
Error:  Failures: 
Error:    RunRpcTest.Flag change event 1 expectation failed.
Expected status code <200> but was <500>.

Error:    RunRpcTest.Flag change event with caching 1 expectation failed.
Expected status code <200> but was <500>.

Error:    RunRpcTest.Use enriched context on RPC connection will not cache the value 1 expectation failed.
Expected status code <200> but was <500>.
```

https://github.com/open-feature/java-sdk-contrib/actions/runs/20754500347/job/59592648835?pr=1624

This change removes the `PauseFileWatcher` and `ContinueFileWatcher` funcs, and instead just allows to the `filewatcher` to be safely restarted, preventing this deadlock. I ran this against the Java suite locally and it fixed the intermittent failure caused by the deadlock