### PR TITLE
feat(semver): add edge case scenarios for v-prefix, partial versions, and build metadata

### DIFF
--- a/evaluator/flags/testkit-flags.json
+++ b/evaluator/flags/testkit-flags.json
@@ -474,6 +474,30 @@
           ["two", 50]
         ]
       }
+    },
+    "semver-v-prefix-flag": {
+      "state": "ENABLED",
+      "variants": { "match": "match", "no-match": "no-match" },
+      "defaultVariant": "no-match",
+      "targeting": {
+        "if": [{"sem_ver": [{"var": "version"}, "=", "v1.0.0"]}, "match", "no-match"]
+      }
+    },
+    "semver-partial-version-flag": {
+      "state": "ENABLED",
+      "variants": { "match": "match", "no-match": "no-match" },
+      "defaultVariant": "no-match",
+      "targeting": {
+        "if": [{"sem_ver": [{"var": "version"}, "^", "1"]}, "match", "no-match"]
+      }
+    },
+    "semver-build-metadata-flag": {
+      "state": "ENABLED",
+      "variants": { "match": "match", "no-match": "no-match" },
+      "defaultVariant": "no-match",
+      "targeting": {
+        "if": [{"sem_ver": [{"var": "version"}, "=", "1.0.0+build"]}, "match", "no-match"]
+      }
     }
   },
   "$evaluators": {

--- a/evaluator/gherkin/semver.feature
+++ b/evaluator/gherkin/semver.feature
@@ -43,3 +43,42 @@ Feature: Evaluator semantic version operator
       | key                          | context_value |
       | semver-invalid-version-flag  | not-a-version |
       | semver-invalid-operator-flag | 1.0.0         |
+
+  @semver-edge-cases
+  Scenario Outline: v-prefix handling
+    Given an evaluator
+    And a String-flag with key "semver-v-prefix-flag" and a fallback value "fallback"
+    And a context containing a key "version", with type "String" and with value "<version>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<value>"
+    Examples:
+      | version | value    |
+      | 1.0.0   | match    |
+      | v1.0.0  | match    |
+      | 2.0.0   | no-match |
+
+  @semver-edge-cases
+  Scenario Outline: partial version handling
+    Given an evaluator
+    And a String-flag with key "semver-partial-version-flag" and a fallback value "fallback"
+    And a context containing a key "version", with type "String" and with value "<version>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<value>"
+    Examples:
+      | version | value    |
+      | 1.5.0   | match    |
+      | 1.0.0   | match    |
+      | 2.0.0   | no-match |
+
+  @semver-edge-cases
+  Scenario Outline: build metadata ignored in comparison
+    Given an evaluator
+    And a String-flag with key "semver-build-metadata-flag" and a fallback value "fallback"
+    And a context containing a key "version", with type "String" and with value "<version>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<value>"
+    Examples:
+      | version     | value    |
+      | 1.0.0       | match    |
+      | 1.0.0+other | match    |
+      | 2.0.0       | no-match |

--- a/evaluator/gherkin/semver.feature
+++ b/evaluator/gherkin/semver.feature
@@ -55,20 +55,24 @@ Feature: Evaluator semantic version operator
       | version | value    |
       | 1.0.0   | match    |
       | v1.0.0  | match    |
+      | V1.0.0  | match    |
       | 2.0.0   | no-match |
 
   @semver-edge-cases @semver-partial-version
   Scenario Outline: partial version handling
     Given an evaluator
     And a String-flag with key "semver-partial-version-flag" and a fallback value "fallback"
-    And a context containing a key "version", with type "String" and with value "<version>"
+    And a context containing a key "version", with type "<type>" and with value "<version>"
     When the flag was evaluated with details
     Then the resolved details value should be "<value>"
     Examples:
-      | version | value    |
-      | 1.5.0   | match    |
-      | 1.0.0   | match    |
-      | 2.0.0   | no-match |
+      | version | type    | value    |
+      | 1.5.0   | String  | match    |
+      | 1.0.0   | String  | match    |
+      | 1.0     | String  | match    |
+      | 1       | String  | match    |
+      | 1       | Integer | match    |
+      | 2.0.0   | String  | no-match |
 
   @semver-edge-cases @semver-build-metadata
   Scenario Outline: build metadata ignored in comparison

--- a/evaluator/gherkin/semver.feature
+++ b/evaluator/gherkin/semver.feature
@@ -44,7 +44,7 @@ Feature: Evaluator semantic version operator
       | semver-invalid-version-flag  | not-a-version |
       | semver-invalid-operator-flag | 1.0.0         |
 
-  @semver-edge-cases
+  @semver-edge-cases @semver-v-prefix
   Scenario Outline: v-prefix handling
     Given an evaluator
     And a String-flag with key "semver-v-prefix-flag" and a fallback value "fallback"
@@ -57,7 +57,7 @@ Feature: Evaluator semantic version operator
       | v1.0.0  | match    |
       | 2.0.0   | no-match |
 
-  @semver-edge-cases
+  @semver-edge-cases @semver-partial-version
   Scenario Outline: partial version handling
     Given an evaluator
     And a String-flag with key "semver-partial-version-flag" and a fallback value "fallback"
@@ -70,7 +70,7 @@ Feature: Evaluator semantic version operator
       | 1.0.0   | match    |
       | 2.0.0   | no-match |
 
-  @semver-edge-cases
+  @semver-edge-cases @semver-build-metadata
   Scenario Outline: build metadata ignored in comparison
     Given an evaluator
     And a String-flag with key "semver-build-metadata-flag" and a fallback value "fallback"

--- a/flags/custom-ops.json
+++ b/flags/custom-ops.json
@@ -299,6 +299,48 @@
           }
         ]
       }
+    },
+    "semver-v-prefix-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "match": "match",
+        "no-match": "no-match"
+      },
+      "defaultVariant": "no-match",
+      "targeting": {
+        "if": [
+          {"sem_ver": [{"var": "version"}, "=", "v1.0.0"]},
+          "match", "no-match"
+        ]
+      }
+    },
+    "semver-partial-version-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "match": "match",
+        "no-match": "no-match"
+      },
+      "defaultVariant": "no-match",
+      "targeting": {
+        "if": [
+          {"sem_ver": [{"var": "version"}, "^", "1"]},
+          "match", "no-match"
+        ]
+      }
+    },
+    "semver-build-metadata-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "match": "match",
+        "no-match": "no-match"
+      },
+      "defaultVariant": "no-match",
+      "targeting": {
+        "if": [
+          {"sem_ver": [{"var": "version"}, "=", "1.0.0+build"]},
+          "match", "no-match"
+        ]
+      }
     }
   }
 }

--- a/gherkin/targeting.feature
+++ b/gherkin/targeting.feature
@@ -240,6 +240,42 @@ Feature: Targeting rules
       | 3.1.0   | major |
       | 4.0.0   | none  |
 
+  @semver @semver-edge-cases
+  Scenario Outline: sem_ver v-prefix handling
+    Given a String-flag with key "semver-v-prefix-flag" and a default value "fallback"
+    And a context containing a key "version", with type "String" and with value "<version>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<value>"
+    Examples:
+      | version | value    |
+      | 1.0.0   | match    |
+      | v1.0.0  | match    |
+      | 2.0.0   | no-match |
+
+  @semver @semver-edge-cases
+  Scenario Outline: sem_ver partial version handling
+    Given a String-flag with key "semver-partial-version-flag" and a default value "fallback"
+    And a context containing a key "version", with type "String" and with value "<version>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<value>"
+    Examples:
+      | version | value    |
+      | 1.5.0   | match    |
+      | 1.0.0   | match    |
+      | 2.0.0   | no-match |
+
+  @semver @semver-edge-cases
+  Scenario Outline: sem_ver build metadata ignored
+    Given a String-flag with key "semver-build-metadata-flag" and a default value "fallback"
+    And a context containing a key "version", with type "String" and with value "<version>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<value>"
+    Examples:
+      | version       | value    |
+      | 1.0.0         | match    |
+      | 1.0.0+other   | match    |
+      | 2.0.0         | no-match |
+
   Scenario Outline: Time-based operations
     Given a Integer-flag with key "timestamp-flag" and a default value "0"
     And a context containing a key "time", with type "Integer" and with value "<time>"

--- a/gherkin/targeting.feature
+++ b/gherkin/targeting.feature
@@ -250,19 +250,23 @@ Feature: Targeting rules
       | version | value    |
       | 1.0.0   | match    |
       | v1.0.0  | match    |
+      | V1.0.0  | match    |
       | 2.0.0   | no-match |
 
   @semver @semver-edge-cases @semver-partial-version
   Scenario Outline: sem_ver partial version handling
     Given a String-flag with key "semver-partial-version-flag" and a default value "fallback"
-    And a context containing a key "version", with type "String" and with value "<version>"
+    And a context containing a key "version", with type "<type>" and with value "<version>"
     When the flag was evaluated with details
     Then the resolved details value should be "<value>"
     Examples:
-      | version | value    |
-      | 1.5.0   | match    |
-      | 1.0.0   | match    |
-      | 2.0.0   | no-match |
+      | version | type    | value    |
+      | 1.5.0   | String  | match    |
+      | 1.0.0   | String  | match    |
+      | 1.0     | String  | match    |
+      | 1       | String  | match    |
+      | 1       | Integer | match    |
+      | 2.0.0   | String  | no-match |
 
   @semver @semver-edge-cases @semver-build-metadata
   Scenario Outline: sem_ver build metadata ignored

--- a/gherkin/targeting.feature
+++ b/gherkin/targeting.feature
@@ -240,7 +240,7 @@ Feature: Targeting rules
       | 3.1.0   | major |
       | 4.0.0   | none  |
 
-  @semver @semver-edge-cases
+  @semver @semver-edge-cases @semver-v-prefix
   Scenario Outline: sem_ver v-prefix handling
     Given a String-flag with key "semver-v-prefix-flag" and a default value "fallback"
     And a context containing a key "version", with type "String" and with value "<version>"
@@ -252,7 +252,7 @@ Feature: Targeting rules
       | v1.0.0  | match    |
       | 2.0.0   | no-match |
 
-  @semver @semver-edge-cases
+  @semver @semver-edge-cases @semver-partial-version
   Scenario Outline: sem_ver partial version handling
     Given a String-flag with key "semver-partial-version-flag" and a default value "fallback"
     And a context containing a key "version", with type "String" and with value "<version>"
@@ -264,7 +264,7 @@ Feature: Targeting rules
       | 1.0.0   | match    |
       | 2.0.0   | no-match |
 
-  @semver @semver-edge-cases
+  @semver @semver-edge-cases @semver-build-metadata
   Scenario Outline: sem_ver build metadata ignored
     Given a String-flag with key "semver-build-metadata-flag" and a default value "fallback"
     And a context containing a key "version", with type "String" and with value "<version>"


### PR DESCRIPTION
## Summary

Adds `@semver-edge-cases` tagged scenarios to `targeting.feature` covering edge cases from [flagd#1873](https://github.com/open-feature/flagd/issues/1873).

## New Tag

`@semver @semver-edge-cases` — SDK implementations can opt in to run these as part of their `@semver` suite or target `@semver-edge-cases` independently.

## New Scenarios

### v-prefix handling (`semver-v-prefix-flag`)
Rule compares against `v1.0.0` (v-prefixed). Both `1.0.0` and `v1.0.0` in context should match — the prefix is stripped transparently on both sides.

| context version | expected |
|---|---|
| `1.0.0` | match |
| `v1.0.0` | match |
| `2.0.0` | no-match |

### Partial version handling (`semver-partial-version-flag`)
Rule compares against `1` (partial — missing minor and patch). Should be treated as `1.0.0` and match any compatible `1.x.y`.

| context version | expected |
|---|---|
| `1.5.0` | match |
| `1.0.0` | match |
| `2.0.0` | no-match |

### Build metadata ignored (`semver-build-metadata-flag`)
Rule compares against `1.0.0+build`. Build metadata MUST be ignored per SemVer 2.0.0 Rule 10 — so `1.0.0` and `1.0.0+other` both equal `1.0.0+build`.

| context version | expected |
|---|---|
| `1.0.0` | match |
| `1.0.0+other` | match |
| `2.0.0` | no-match |

## Related

- [flagd#1873](https://github.com/open-feature/flagd/issues/1873) — root bug report
- [flagd-evaluator#20](https://github.com/open-feature/flagd-evaluator/issues/20) — evaluator tracking issue