### PR TITLE
feat(evaluators): add nested $ref resolution scenarios

### DIFF
--- a/evaluator/flags/testkit-flags.json
+++ b/evaluator/flags/testkit-flags.json
@@ -474,6 +474,18 @@
           ["two", 50]
         ]
       }
+    },
+    "nested-ref-targeted-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "privileged": "privileged",
+        "standard": "standard",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [{"$ref": "is_privileged"}, "privileged", "standard"]
+      }
     }
   },
   "$evaluators": {
@@ -481,6 +493,12 @@
       "==": [
         "ballmer@macrosoft.com",
         {"var": ["email"]}
+      ]
+    },
+    "is_privileged": {
+      "or": [
+        {"$ref": "is_ballmer"},
+        {"==": ["admin", {"var": ["role"]}]}
       ]
     }
   }

--- a/evaluator/flags/testkit-flags.json
+++ b/evaluator/flags/testkit-flags.json
@@ -497,7 +497,7 @@
     },
     "is_privileged": {
       "or": [
-        {"$ref": "is_ballmer"},
+        {"==": ["ballmer@macrosoft.com", {"var": ["email"]}]},
         {"==": ["admin", {"var": ["role"]}]}
       ]
     }

--- a/evaluator/gherkin/evaluator-refs.feature
+++ b/evaluator/gherkin/evaluator-refs.feature
@@ -13,3 +13,16 @@ Feature: Evaluator evaluator refs
       | key                            | value |
       | some-email-targeted-flag       | hi    |
       | some-other-email-targeted-flag | yes   |
+
+  @evaluator-ref-edge-cases
+  Scenario Outline: Nested evaluator ref resolution
+    Given an evaluator
+    And a String-flag with key "nested-ref-targeted-flag" and a fallback value "fallback"
+    And a context containing a key "<context_key>", with type "String" and with value "<context_value>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<value>"
+    Examples:
+      | context_key | context_value         | value      |
+      | email       | ballmer@macrosoft.com | privileged |
+      | role        | admin                 | privileged |
+      | email       | other@example.com     | standard   |

--- a/flags/evaluator-refs.json
+++ b/flags/evaluator-refs.json
@@ -66,7 +66,12 @@
     },
     "is_privileged": {
       "or": [
-        {"$ref": "is_ballmer"},
+        {
+          "==": [
+            "ballmer@macrosoft.com",
+            {"var": ["email"]}
+          ]
+        },
         {
           "==": [
             "admin",

--- a/flags/evaluator-refs.json
+++ b/flags/evaluator-refs.json
@@ -35,6 +35,24 @@
           "no"
         ]
       }
+    },
+    "nested-ref-targeted-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "privileged": "privileged",
+        "standard": "standard",
+        "none": "none"
+      },
+      "defaultVariant": "none",
+      "targeting": {
+        "if": [
+          {
+            "$ref": "is_privileged"
+          },
+          "privileged",
+          "standard"
+        ]
+      }
     }
   },
   "$evaluators": {
@@ -42,8 +60,17 @@
       "==": [
         "ballmer@macrosoft.com",
         {
-          "var": [
-            "email"
+          "var": ["email"]
+        }
+      ]
+    },
+    "is_privileged": {
+      "or": [
+        {"$ref": "is_ballmer"},
+        {
+          "==": [
+            "admin",
+            {"var": ["role"]}
           ]
         }
       ]

--- a/gherkin/targeting.feature
+++ b/gherkin/targeting.feature
@@ -10,6 +10,7 @@ Feature: Targeting rules
     And a stable flagd provider
 
   # evaluator refs
+  @evaluator-refs
   Scenario Outline: Evaluator reuse
     Given a String-flag with key "<key>" and a default value "fallback"
     And a context containing a key "email", with type "String" and with value "ballmer@macrosoft.com"
@@ -19,6 +20,18 @@ Feature: Targeting rules
       | key                            | value |
       | some-email-targeted-flag       | hi    |
       | some-other-email-targeted-flag | yes   |
+
+  @evaluator-refs @evaluator-ref-edge-cases
+  Scenario Outline: Nested evaluator ref resolution
+    Given a String-flag with key "nested-ref-targeted-flag" and a default value "fallback"
+    And a context containing a key "<context_key>", with type "String" and with value "<context_value>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<value>"
+    Examples:
+      | context_key | context_value         | value      |
+      | email       | ballmer@macrosoft.com | privileged |
+      | role        | admin                 | privileged |
+      | email       | other@example.com     | standard   |
 
   # custom operators
   # @fractional-v1: legacy float-based bucketing (abs(hash) / i32::MAX * 100)


### PR DESCRIPTION
## Summary

Adds `@evaluator-refs` and `@evaluator-ref-edge-cases` tagged scenarios to `targeting.feature` covering recursive `$ref` resolution from [flagd#1875](https://github.com/open-feature/flagd/issues/1875).

## New Tags

- `@evaluator-refs` — added to the existing basic evaluator reuse scenario (previously untagged)
- `@evaluator-ref-edge-cases` — for the new nested resolution scenario

## Changes

### Existing scenario tagged
The existing "Evaluator reuse" scenario now has `@evaluator-refs` so SDK implementations can explicitly opt in.

### New: Nested $ref resolution (`nested-ref-targeted-flag`)
A new `is_privileged` evaluator in `evaluator-refs.json` references `is_ballmer` via `$ref`:

```json
"is_privileged": {
  "or": [
    {"$ref": "is_ballmer"},
    {"==": ["admin", {"var": ["role"]}]}
  ]
}
```

The `nested-ref-targeted-flag` uses `$ref: is_privileged`, requiring two levels of resolution. Tests:

| context | expected |
|---|---|
| `email = ballmer@macrosoft.com` | privileged (via nested is_ballmer) |
| `role = admin` | privileged (via direct admin check) |
| `email = other@example.com` | standard (neither condition met) |

## Related

- [flagd#1875](https://github.com/open-feature/flagd/issues/1875) — root bug report
- [flagd-evaluator#22](https://github.com/open-feature/flagd-evaluator/issues/22) — evaluator tracking issue