### PR TITLE
feat(operators): add follow-up error scenarios for operator null-return behaviour

### DIFF
--- a/evaluator/flags/testkit-flags.json
+++ b/evaluator/flags/testkit-flags.json
@@ -583,6 +583,70 @@
           "miss"
         ]
       }
+    },
+    "starts-with-non-string-flag": {
+      "state": "ENABLED",
+      "variants": { "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "starts_with": [{"var": "num"}, "abc"]
+      }
+    },
+    "ends-with-non-string-flag": {
+      "state": "ENABLED",
+      "variants": { "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "ends_with": [{"var": "num"}, "xyz"]
+      }
+    },
+    "starts-with-wrong-args-flag": {
+      "state": "ENABLED",
+      "variants": { "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "starts_with": ["abc"]
+      }
+    },
+    "ends-with-wrong-args-flag": {
+      "state": "ENABLED",
+      "variants": { "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "ends_with": ["xyz"]
+      }
+    },
+    "fractional-zero-weights-flag": {
+      "state": "ENABLED",
+      "variants": { "one": "one", "two": "two", "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "fractional": [
+          {"var": "targetingKey"},
+          ["one", 0],
+          ["two", 0]
+        ]
+      }
+    },
+    "fractional-negative-weight-flag": {
+      "state": "ENABLED",
+      "variants": { "one": "one", "two": "two", "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "fractional": [
+          {"var": "targetingKey"},
+          ["one", -50],
+          ["two", 100]
+        ]
+      }
+    },
+    "semver-wrong-args-flag": {
+      "state": "ENABLED",
+      "variants": { "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "sem_ver": [{"var": "version"}, "="]
+      }
     }
   },
   "$evaluators": {

--- a/evaluator/flags/testkit-flags.json
+++ b/evaluator/flags/testkit-flags.json
@@ -462,29 +462,38 @@
     },
     "semver-invalid-version-flag": {
       "state": "ENABLED",
-      "variants": { "match": "match", "no-match": "no-match", "fallback": "fallback" },
+      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "sem_ver": [{"var": "version"}, "=", "1.0.0"]
+        "if": [
+          {"sem_ver": [{"var": "version"}, "=", "1.0.0"]},
+          "true", "false"
+        ]
       }
     },
     "semver-invalid-operator-flag": {
       "state": "ENABLED",
-      "variants": { "match": "match", "no-match": "no-match", "fallback": "fallback" },
+      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "sem_ver": [{"var": "version"}, "===", "1.0.0"]
+        "if": [
+          {"sem_ver": [{"var": "version"}, "===", "1.0.0"]},
+          "true", "false"
+        ]
       }
     },
     "fractional-null-bucket-key-flag": {
       "state": "ENABLED",
-      "variants": { "one": "one", "two": "two", "fallback": "fallback" },
+      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "fractional": [
-          {"var": "missing_key"},
-          ["one", 50],
-          ["two", 50]
+        "if": [
+          {"fractional": [
+            {"var": "missing_key"},
+            ["one", 50],
+            ["two", 50]
+          ]},
+          "true", "false"
         ]
       }
     },
@@ -586,45 +595,60 @@
     },
     "starts-with-non-string-flag": {
       "state": "ENABLED",
-      "variants": { "fallback": "fallback" },
+      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "starts_with": [{"var": "num"}, "abc"]
+        "if": [
+          {"starts_with": [{"var": "num"}, "abc"]},
+          "true", "false"
+        ]
       }
     },
     "ends-with-non-string-flag": {
       "state": "ENABLED",
-      "variants": { "fallback": "fallback" },
+      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "ends_with": [{"var": "num"}, "xyz"]
+        "if": [
+          {"ends_with": [{"var": "num"}, "xyz"]},
+          "true", "false"
+        ]
       }
     },
     "starts-with-wrong-args-flag": {
       "state": "ENABLED",
-      "variants": { "fallback": "fallback" },
+      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "starts_with": ["abc"]
+        "if": [
+          {"starts_with": ["abc"]},
+          "true", "false"
+        ]
       }
     },
     "ends-with-wrong-args-flag": {
       "state": "ENABLED",
-      "variants": { "fallback": "fallback" },
+      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "ends_with": ["xyz"]
+        "if": [
+          {"ends_with": ["xyz"]},
+          "true", "false"
+        ]
       }
     },
     "fractional-zero-weights-flag": {
       "state": "ENABLED",
-      "variants": { "one": "one", "two": "two", "fallback": "fallback" },
+      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "fractional": [
-          {"var": "targetingKey"},
-          ["one", 0],
-          ["two", 0]
+        "if": [
+          {"fractional": [
+            {"var": "targetingKey"},
+            ["one", 0],
+            ["two", 0]
+          ]},
+          "true", "false"
         ]
       }
     },
@@ -642,10 +666,13 @@
     },
     "semver-wrong-args-flag": {
       "state": "ENABLED",
-      "variants": { "fallback": "fallback" },
+      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "sem_ver": [{"var": "version"}, "="]
+        "if": [
+          {"sem_ver": [{"var": "version"}, "="]},
+          "true", "false"
+        ]
       }
     }
   },

--- a/evaluator/gherkin/fractional.feature
+++ b/evaluator/gherkin/fractional.feature
@@ -195,6 +195,8 @@ Feature: Evaluator fractional operator
     And a String-flag with key "fractional-null-bucket-key-flag" and a fallback value "wrong"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"
+
   # Follow-up error scenarios from https://github.com/open-feature/flagd/issues/1874
 
   @operator-errors
@@ -204,6 +206,7 @@ Feature: Evaluator fractional operator
     And a context containing a targeting key with value "any-user"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"
 
   @operator-errors
   Scenario: fractional negative bucket weight is clamped to zero

--- a/evaluator/gherkin/fractional.feature
+++ b/evaluator/gherkin/fractional.feature
@@ -195,3 +195,21 @@ Feature: Evaluator fractional operator
     And a String-flag with key "fractional-null-bucket-key-flag" and a fallback value "wrong"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+  # Follow-up error scenarios from https://github.com/open-feature/flagd/issues/1874
+
+  @operator-errors
+  Scenario: fractional with all-zero bucket weights falls back to default variant
+    Given an evaluator
+    And a String-flag with key "fractional-zero-weights-flag" and a fallback value "wrong"
+    And a context containing a targeting key with value "any-user"
+    When the flag was evaluated with details
+    Then the resolved details value should be "fallback"
+
+  @operator-errors
+  Scenario: fractional negative bucket weight is clamped to zero
+    # ["one", -50] is treated as ["one", 0]; "two" gets 100% of the weight
+    Given an evaluator
+    And a String-flag with key "fractional-negative-weight-flag" and a fallback value "wrong"
+    And a context containing a targeting key with value "any-user"
+    When the flag was evaluated with details
+    Then the resolved details value should be "two"

--- a/evaluator/gherkin/semver.feature
+++ b/evaluator/gherkin/semver.feature
@@ -39,6 +39,7 @@ Feature: Evaluator semantic version operator
     And a context containing a key "version", with type "String" and with value "<context_value>"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"
     Examples:
       | key                          | context_value |
       | semver-invalid-version-flag  | not-a-version |
@@ -96,3 +97,4 @@ Feature: Evaluator semantic version operator
     And a context containing a key "version", with type "String" and with value "1.0.0"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"

--- a/evaluator/gherkin/semver.feature
+++ b/evaluator/gherkin/semver.feature
@@ -86,3 +86,13 @@ Feature: Evaluator semantic version operator
       | 1.0.0       | match    |
       | 1.0.0+other | match    |
       | 2.0.0       | no-match |
+
+  # Follow-up error scenarios from https://github.com/open-feature/flagd/issues/1874
+
+  @operator-errors
+  Scenario: sem_ver returns null for wrong argument count
+    Given an evaluator
+    And a String-flag with key "semver-wrong-args-flag" and a fallback value "wrong"
+    And a context containing a key "version", with type "String" and with value "1.0.0"
+    When the flag was evaluated with details
+    Then the resolved details value should be "fallback"

--- a/evaluator/gherkin/string.feature
+++ b/evaluator/gherkin/string.feature
@@ -28,6 +28,7 @@ Feature: Evaluator string comparison operator
     And a context containing a key "num", with type "Integer" and with value "123"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"
     Examples:
       | key                         |
       | starts-with-non-string-flag |
@@ -39,6 +40,7 @@ Feature: Evaluator string comparison operator
     And a String-flag with key "<key>" and a fallback value "wrong"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"
     Examples:
       | key                         |
       | starts-with-wrong-args-flag |

--- a/evaluator/gherkin/string.feature
+++ b/evaluator/gherkin/string.feature
@@ -16,3 +16,30 @@ Feature: Evaluator string comparison operator
       | uvwxyz | postfix |
       | abcxyz | prefix  |
       | lmnopq | none    |
+
+  # Follow-up error scenarios from https://github.com/open-feature/flagd/issues/1874
+  # starts_with and ends_with must return null (not false) on error so that the
+  # default variant is selected, rather than looking up a non-existent "false" variant.
+
+  @operator-errors
+  Scenario Outline: starts_with and ends_with return null for non-string input
+    Given an evaluator
+    And a String-flag with key "<key>" and a fallback value "wrong"
+    And a context containing a key "num", with type "Integer" and with value "123"
+    When the flag was evaluated with details
+    Then the resolved details value should be "fallback"
+    Examples:
+      | key                         |
+      | starts-with-non-string-flag |
+      | ends-with-non-string-flag   |
+
+  @operator-errors
+  Scenario Outline: starts_with and ends_with return null for wrong argument count
+    Given an evaluator
+    And a String-flag with key "<key>" and a fallback value "wrong"
+    When the flag was evaluated with details
+    Then the resolved details value should be "fallback"
+    Examples:
+      | key                         |
+      | starts-with-wrong-args-flag |
+      | ends-with-wrong-args-flag   |

--- a/flags/edge-case-flags.json
+++ b/flags/edge-case-flags.json
@@ -56,84 +56,128 @@
     "semver-invalid-version-flag": {
       "state": "ENABLED",
       "variants": {
-        "match": "match",
-        "no-match": "no-match",
+        "true": "true",
+        "false": "false",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "sem_ver": [{"var": "version"}, "=", "1.0.0"]
+        "if": [
+          {"sem_ver": [{"var": "version"}, "=", "1.0.0"]},
+          "true", "false"
+        ]
       }
     },
     "semver-invalid-operator-flag": {
       "state": "ENABLED",
       "variants": {
-        "match": "match",
-        "no-match": "no-match",
+        "true": "true",
+        "false": "false",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "sem_ver": [{"var": "version"}, "===", "1.0.0"]
+        "if": [
+          {"sem_ver": [{"var": "version"}, "===", "1.0.0"]},
+          "true", "false"
+        ]
       }
     },
     "fractional-null-bucket-key-flag": {
       "state": "ENABLED",
       "variants": {
-        "one": "one",
-        "two": "two",
+        "true": "true",
+        "false": "false",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "fractional": [
-          {"var": "missing_key"},
-          ["one", 50],
-          ["two", 50]
+        "if": [
+          {"fractional": [
+            {"var": "missing_key"},
+            ["one", 50],
+            ["two", 50]
+          ]},
+          "true", "false"
         ]
       }
     },
     "starts-with-non-string-flag": {
       "state": "ENABLED",
-      "variants": { "fallback": "fallback" },
+      "variants": {
+        "true": "true",
+        "false": "false",
+        "fallback": "fallback"
+      },
       "defaultVariant": "fallback",
       "targeting": {
-        "starts_with": [{"var": "num"}, "abc"]
+        "if": [
+          {"starts_with": [{"var": "num"}, "abc"]},
+          "true", "false"
+        ]
       }
     },
     "ends-with-non-string-flag": {
       "state": "ENABLED",
-      "variants": { "fallback": "fallback" },
+      "variants": {
+        "true": "true",
+        "false": "false",
+        "fallback": "fallback"
+      },
       "defaultVariant": "fallback",
       "targeting": {
-        "ends_with": [{"var": "num"}, "xyz"]
+        "if": [
+          {"ends_with": [{"var": "num"}, "xyz"]},
+          "true", "false"
+        ]
       }
     },
     "starts-with-wrong-args-flag": {
       "state": "ENABLED",
-      "variants": { "fallback": "fallback" },
+      "variants": {
+        "true": "true",
+        "false": "false",
+        "fallback": "fallback"
+      },
       "defaultVariant": "fallback",
       "targeting": {
-        "starts_with": ["abc"]
+        "if": [
+          {"starts_with": ["abc"]},
+          "true", "false"
+        ]
       }
     },
     "ends-with-wrong-args-flag": {
       "state": "ENABLED",
-      "variants": { "fallback": "fallback" },
+      "variants": {
+        "true": "true",
+        "false": "false",
+        "fallback": "fallback"
+      },
       "defaultVariant": "fallback",
       "targeting": {
-        "ends_with": ["xyz"]
+        "if": [
+          {"ends_with": ["xyz"]},
+          "true", "false"
+        ]
       }
     },
     "fractional-zero-weights-flag": {
       "state": "ENABLED",
-      "variants": { "one": "one", "two": "two", "fallback": "fallback" },
+      "variants": {
+        "true": "true",
+        "false": "false",
+        "fallback": "fallback"
+      },
       "defaultVariant": "fallback",
       "targeting": {
-        "fractional": [
-          {"var": "targetingKey"},
-          ["one", 0],
-          ["two", 0]
+        "if": [
+          {"fractional": [
+            {"var": "targetingKey"},
+            ["one", 0],
+            ["two", 0]
+          ]},
+          "true", "false"
         ]
       }
     },
@@ -151,10 +195,17 @@
     },
     "semver-wrong-args-flag": {
       "state": "ENABLED",
-      "variants": { "fallback": "fallback" },
+      "variants": {
+        "true": "true",
+        "false": "false",
+        "fallback": "fallback"
+      },
       "defaultVariant": "fallback",
       "targeting": {
-        "sem_ver": [{"var": "version"}, "="]
+        "if": [
+          {"sem_ver": [{"var": "version"}, "="]},
+          "true", "false"
+        ]
       }
     }
   }

--- a/flags/edge-case-flags.json
+++ b/flags/edge-case-flags.json
@@ -92,6 +92,70 @@
           ["two", 50]
         ]
       }
+    },
+    "starts-with-non-string-flag": {
+      "state": "ENABLED",
+      "variants": { "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "starts_with": [{"var": "num"}, "abc"]
+      }
+    },
+    "ends-with-non-string-flag": {
+      "state": "ENABLED",
+      "variants": { "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "ends_with": [{"var": "num"}, "xyz"]
+      }
+    },
+    "starts-with-wrong-args-flag": {
+      "state": "ENABLED",
+      "variants": { "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "starts_with": ["abc"]
+      }
+    },
+    "ends-with-wrong-args-flag": {
+      "state": "ENABLED",
+      "variants": { "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "ends_with": ["xyz"]
+      }
+    },
+    "fractional-zero-weights-flag": {
+      "state": "ENABLED",
+      "variants": { "one": "one", "two": "two", "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "fractional": [
+          {"var": "targetingKey"},
+          ["one", 0],
+          ["two", 0]
+        ]
+      }
+    },
+    "fractional-negative-weight-flag": {
+      "state": "ENABLED",
+      "variants": { "one": "one", "two": "two", "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "fractional": [
+          {"var": "targetingKey"},
+          ["one", -50],
+          ["two", 100]
+        ]
+      }
+    },
+    "semver-wrong-args-flag": {
+      "state": "ENABLED",
+      "variants": { "fallback": "fallback" },
+      "defaultVariant": "fallback",
+      "targeting": {
+        "sem_ver": [{"var": "version"}, "="]
+      }
     }
   }
 }

--- a/gherkin/targeting.feature
+++ b/gherkin/targeting.feature
@@ -349,6 +349,7 @@ Feature: Targeting rules
     And a context containing a key "version", with type "String" and with value "<context_value>"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"
     Examples:
       | key                          | context_value   |
       | semver-invalid-version-flag  | not-a-version   |
@@ -359,6 +360,8 @@ Feature: Targeting rules
     Given a String-flag with key "fractional-null-bucket-key-flag" and a default value "wrong"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"
+
   # Follow-up error scenarios from https://github.com/open-feature/flagd/issues/1874
   # Operators must return null (not false) on error so the default variant is selected.
 
@@ -368,6 +371,7 @@ Feature: Targeting rules
     And a context containing a key "num", with type "Integer" and with value "123"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"
     Examples:
       | key                         |
       | starts-with-non-string-flag |
@@ -378,8 +382,9 @@ Feature: Targeting rules
     Given a String-flag with key "<key>" and a default value "wrong"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"
     Examples:
-      | key                        |
+      | key                         |
       | starts-with-wrong-args-flag |
       | ends-with-wrong-args-flag   |
 
@@ -389,6 +394,7 @@ Feature: Targeting rules
     And a context containing a key "version", with type "String" and with value "1.0.0"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"
 
   @operator-errors @fractional
   Scenario: fractional with all-zero bucket weights falls back to default variant
@@ -396,6 +402,7 @@ Feature: Targeting rules
     And a context containing a targeting key with value "any-user"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+    And the reason should be "DEFAULT"
 
   @operator-errors @fractional
   Scenario: fractional negative bucket weight is clamped to zero

--- a/gherkin/targeting.feature
+++ b/gherkin/targeting.feature
@@ -359,3 +359,48 @@ Feature: Targeting rules
     Given a String-flag with key "fractional-null-bucket-key-flag" and a default value "wrong"
     When the flag was evaluated with details
     Then the resolved details value should be "fallback"
+  # Follow-up error scenarios from https://github.com/open-feature/flagd/issues/1874
+  # Operators must return null (not false) on error so the default variant is selected.
+
+  @operator-errors @string
+  Scenario Outline: starts_with and ends_with return null for non-string input
+    Given a String-flag with key "<key>" and a default value "wrong"
+    And a context containing a key "num", with type "Integer" and with value "123"
+    When the flag was evaluated with details
+    Then the resolved details value should be "fallback"
+    Examples:
+      | key                         |
+      | starts-with-non-string-flag |
+      | ends-with-non-string-flag   |
+
+  @operator-errors @string
+  Scenario Outline: starts_with and ends_with return null for wrong argument count
+    Given a String-flag with key "<key>" and a default value "wrong"
+    When the flag was evaluated with details
+    Then the resolved details value should be "fallback"
+    Examples:
+      | key                        |
+      | starts-with-wrong-args-flag |
+      | ends-with-wrong-args-flag   |
+
+  @operator-errors @semver
+  Scenario: sem_ver returns null for wrong argument count
+    Given a String-flag with key "semver-wrong-args-flag" and a default value "wrong"
+    And a context containing a key "version", with type "String" and with value "1.0.0"
+    When the flag was evaluated with details
+    Then the resolved details value should be "fallback"
+
+  @operator-errors @fractional
+  Scenario: fractional with all-zero bucket weights falls back to default variant
+    Given a String-flag with key "fractional-zero-weights-flag" and a default value "wrong"
+    And a context containing a targeting key with value "any-user"
+    When the flag was evaluated with details
+    Then the resolved details value should be "fallback"
+
+  @operator-errors @fractional
+  Scenario: fractional negative bucket weight is clamped to zero
+    # ["one", -50] is treated as ["one", 0]; "two" gets 100% of the weight
+    Given a String-flag with key "fractional-negative-weight-flag" and a default value "wrong"
+    And a context containing a targeting key with value "any-user"
+    When the flag was evaluated with details
+    Then the resolved details value should be "two"


### PR DESCRIPTION


Covers the remaining cases from https://github.com/open-feature/flagd/issues/1874 identified in the review of #342:

- starts_with / ends_with: non-string first argument → must return null
- starts_with / ends_with: wrong argument count → must return null
- sem_ver: wrong argument count (missing target version) → must return null
- fractional: all-zero bucket weights (no bucket matched) → must return null
- fractional: negative bucket weight clamped to zero → "one" gets effective weight 0, "two" gets 100% of the weight

All scenarios use a bare operator as the targeting expression (not wrapped in 'if') so a null result selects the defaultVariant directly. Scenarios are tagged @operator-errors and mirrored in both the SDK-level gherkin (gherkin/targeting.feature) and the evaluator-level gherkin files (evaluator/gherkin/{string,semver,fractional}.feature) with matching flag definitions added to both flags/edge-case-flags.json and evaluator/flags/testkit-flags.json.

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds this new feature

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

