### PR TITLE
test: add semver assertions for numeric context values

### DIFF
--- a/evaluator/flags/testkit-flags.json
+++ b/evaluator/flags/testkit-flags.json
@@ -521,6 +521,14 @@
         "if": [{"sem_ver": [{"var": "version"}, "=", "1.0.0+build"]}, "match", "no-match"]
       }
     },
+    "semver-numeric-context-flag": {
+      "state": "ENABLED",
+      "variants": { "match": "match", "no-match": "no-match" },
+      "defaultVariant": "no-match",
+      "targeting": {
+        "if": [{"sem_ver": [{"var": "version"}, ">", "1.1"]}, "match", "no-match"]
+      }
+    },
     "ref-whitespace-compact-flag": {
       "state": "ENABLED",
       "variants": {

--- a/evaluator/gherkin/semver.feature
+++ b/evaluator/gherkin/semver.feature
@@ -60,7 +60,7 @@ Feature: Evaluator semantic version operator
       | 2.0.0   | no-match |
 
   @semver-edge-cases @semver-partial-version
-  Scenario Outline: partial version handling
+  Scenario Outline: partial version string handling
     Given an evaluator
     And a String-flag with key "semver-partial-version-flag" and a fallback value "fallback"
     And a context containing a key "version", with type "<type>" and with value "<version>"
@@ -78,7 +78,7 @@ Feature: Evaluator semantic version operator
       | 2.0.0   | String  | no-match |
 
   @semver-edge-cases @semver-numeric-context
-  Scenario Outline: numeric context value handling
+  Scenario Outline: numeric context value coercion
     Given an evaluator
     And a String-flag with key "semver-numeric-context-flag" and a fallback value "fallback"
     And a context containing a key "version", with type "<type>" and with value "<version>"

--- a/evaluator/gherkin/semver.feature
+++ b/evaluator/gherkin/semver.feature
@@ -73,7 +73,24 @@ Feature: Evaluator semantic version operator
       | 1.0     | String  | match    |
       | 1       | String  | match    |
       | 1       | Integer | match    |
+      | 1       | Float   | match    |
+      | 1.2     | Float   | match    |
       | 2.0.0   | String  | no-match |
+
+  @semver-edge-cases @semver-numeric-context
+  Scenario Outline: numeric context value handling
+    Given an evaluator
+    And a String-flag with key "semver-numeric-context-flag" and a fallback value "fallback"
+    And a context containing a key "version", with type "<type>" and with value "<version>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<value>"
+    Examples:
+      | version | type    | value    |
+      | 1.2     | Float   | match    |
+      | 1.1     | Float   | no-match |
+      | 2       | Integer | match    |
+      | 1       | Integer | no-match |
+      | 1.2     | String  | match    |
 
   @semver-edge-cases @semver-build-metadata
   Scenario Outline: build metadata ignored in comparison

--- a/flags/custom-ops.json
+++ b/flags/custom-ops.json
@@ -341,6 +341,20 @@
         ]
       }
     },
+    "semver-numeric-context-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "match": "match",
+        "no-match": "no-match"
+      },
+      "defaultVariant": "no-match",
+      "targeting": {
+        "if": [
+          {"sem_ver": [{"var": "version"}, ">", "1.1"]},
+          "match", "no-match"
+        ]
+      }
+    },
     "semver-build-metadata-flag": {
       "state": "ENABLED",
       "variants": {

--- a/gherkin/targeting.feature
+++ b/gherkin/targeting.feature
@@ -283,7 +283,7 @@ Feature: Targeting rules
       | 2.0.0   | no-match |
 
   @semver @semver-edge-cases @semver-partial-version
-  Scenario Outline: sem_ver partial version handling
+  Scenario Outline: sem_ver partial version string handling
     Given a String-flag with key "semver-partial-version-flag" and a default value "fallback"
     And a context containing a key "version", with type "<type>" and with value "<version>"
     When the flag was evaluated with details
@@ -295,7 +295,23 @@ Feature: Targeting rules
       | 1.0     | String  | match    |
       | 1       | String  | match    |
       | 1       | Integer | match    |
+      | 1       | Float   | match    |
+      | 1.2     | Float   | match    |
       | 2.0.0   | String  | no-match |
+
+  @semver @semver-edge-cases @semver-numeric-context
+  Scenario Outline: sem_ver numeric context value coercion
+    Given a String-flag with key "semver-numeric-context-flag" and a default value "fallback"
+    And a context containing a key "version", with type "<type>" and with value "<version>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<value>"
+    Examples:
+      | version | type    | value    |
+      | 1.2     | Float   | match    |
+      | 1.1     | Float   | no-match |
+      | 2       | Integer | match    |
+      | 1       | Integer | no-match |
+      | 1.2     | String  | match    |
 
   @semver @semver-edge-cases @semver-build-metadata
   Scenario Outline: sem_ver build metadata ignored


### PR DESCRIPTION
## Summary

Closes #237

- Adds `Float` rows (`1` and `1.2`) to the existing **partial version handling** scenario to assert that float context values are handled correctly by `sem_ver`
- Adds a new `semver-numeric-context-flag` flag definition (using the `>` operator against `"1.1"`) to `evaluator/flags/testkit-flags.json`
- Adds a new **numeric context value handling** scenario (`@semver-numeric-context`) that asserts `Float` and `Integer` context values compare correctly against string semver targets (e.g. `1.2 (Float) > "1.1"` → match)

## Test coverage added

| version | type    | expected |
|---------|---------|----------|
| 1.2     | Float   | match    |
| 1.1     | Float   | no-match |
| 2       | Integer | match    |
| 1       | Integer | no-match |
| 1.2     | String  | match    |
| 1       | Float   | match (partial version) |
| 1.2     | Float   | match (partial version) |