### PR TITLE
fix: remove if-wrappers from operator error flags

### DIFF
--- a/evaluator/flags/testkit-flags.json
+++ b/evaluator/flags/testkit-flags.json
@@ -462,38 +462,29 @@
     },
     "semver-invalid-version-flag": {
       "state": "ENABLED",
-      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
+      "variants": { "match": "match", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"sem_ver": [{"var": "version"}, "=", "1.0.0"]},
-          "true", "false"
-        ]
+        "sem_ver": [{"var": "version"}, "=", "1.0.0"]
       }
     },
     "semver-invalid-operator-flag": {
       "state": "ENABLED",
-      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
+      "variants": { "match": "match", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"sem_ver": [{"var": "version"}, "===", "1.0.0"]},
-          "true", "false"
-        ]
+        "sem_ver": [{"var": "version"}, "===", "1.0.0"]
       }
     },
     "fractional-null-bucket-key-flag": {
       "state": "ENABLED",
-      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
+      "variants": { "one": "one", "two": "two", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"fractional": [
-            {"var": "missing_key"},
-            ["one", 50],
-            ["two", 50]
-          ]},
-          "true", "false"
+        "fractional": [
+          {"var": "missing_key"},
+          ["one", 50],
+          ["two", 50]
         ]
       }
     },
@@ -603,60 +594,45 @@
     },
     "starts-with-non-string-flag": {
       "state": "ENABLED",
-      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
+      "variants": { "match": "match", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"starts_with": [{"var": "num"}, "abc"]},
-          "true", "false"
-        ]
+        "starts_with": [{"var": "num"}, "abc"]
       }
     },
     "ends-with-non-string-flag": {
       "state": "ENABLED",
-      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
+      "variants": { "match": "match", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"ends_with": [{"var": "num"}, "xyz"]},
-          "true", "false"
-        ]
+        "ends_with": [{"var": "num"}, "xyz"]
       }
     },
     "starts-with-wrong-args-flag": {
       "state": "ENABLED",
-      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
+      "variants": { "match": "match", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"starts_with": ["abc"]},
-          "true", "false"
-        ]
+        "starts_with": ["abc"]
       }
     },
     "ends-with-wrong-args-flag": {
       "state": "ENABLED",
-      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
+      "variants": { "match": "match", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"ends_with": ["xyz"]},
-          "true", "false"
-        ]
+        "ends_with": ["xyz"]
       }
     },
     "fractional-zero-weights-flag": {
       "state": "ENABLED",
-      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
+      "variants": { "one": "one", "two": "two", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"fractional": [
-            {"var": "targetingKey"},
-            ["one", 0],
-            ["two", 0]
-          ]},
-          "true", "false"
+        "fractional": [
+          {"var": "targetingKey"},
+          ["one", 0],
+          ["two", 0]
         ]
       }
     },
@@ -674,13 +650,10 @@
     },
     "semver-wrong-args-flag": {
       "state": "ENABLED",
-      "variants": { "true": "true", "false": "false", "fallback": "fallback" },
+      "variants": { "match": "match", "fallback": "fallback" },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"sem_ver": [{"var": "version"}, "="]},
-          "true", "false"
-        ]
+        "sem_ver": [{"var": "version"}, "="]
       }
     }
   },

--- a/flags/edge-case-flags.json
+++ b/flags/edge-case-flags.json
@@ -56,128 +56,98 @@
     "semver-invalid-version-flag": {
       "state": "ENABLED",
       "variants": {
-        "true": "true",
-        "false": "false",
+        "match": "match",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"sem_ver": [{"var": "version"}, "=", "1.0.0"]},
-          "true", "false"
-        ]
+        "sem_ver": [{"var": "version"}, "=", "1.0.0"]
       }
     },
     "semver-invalid-operator-flag": {
       "state": "ENABLED",
       "variants": {
-        "true": "true",
-        "false": "false",
+        "match": "match",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"sem_ver": [{"var": "version"}, "===", "1.0.0"]},
-          "true", "false"
-        ]
+        "sem_ver": [{"var": "version"}, "===", "1.0.0"]
       }
     },
     "fractional-null-bucket-key-flag": {
       "state": "ENABLED",
       "variants": {
-        "true": "true",
-        "false": "false",
+        "one": "one",
+        "two": "two",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"fractional": [
-            {"var": "missing_key"},
-            ["one", 50],
-            ["two", 50]
-          ]},
-          "true", "false"
+        "fractional": [
+          {"var": "missing_key"},
+          ["one", 50],
+          ["two", 50]
         ]
       }
     },
     "starts-with-non-string-flag": {
       "state": "ENABLED",
       "variants": {
-        "true": "true",
-        "false": "false",
+        "match": "match",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"starts_with": [{"var": "num"}, "abc"]},
-          "true", "false"
-        ]
+        "starts_with": [{"var": "num"}, "abc"]
       }
     },
     "ends-with-non-string-flag": {
       "state": "ENABLED",
       "variants": {
-        "true": "true",
-        "false": "false",
+        "match": "match",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"ends_with": [{"var": "num"}, "xyz"]},
-          "true", "false"
-        ]
+        "ends_with": [{"var": "num"}, "xyz"]
       }
     },
     "starts-with-wrong-args-flag": {
       "state": "ENABLED",
       "variants": {
-        "true": "true",
-        "false": "false",
+        "match": "match",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"starts_with": ["abc"]},
-          "true", "false"
-        ]
+        "starts_with": ["abc"]
       }
     },
     "ends-with-wrong-args-flag": {
       "state": "ENABLED",
       "variants": {
-        "true": "true",
-        "false": "false",
+        "match": "match",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"ends_with": ["xyz"]},
-          "true", "false"
-        ]
+        "ends_with": ["xyz"]
       }
     },
     "fractional-zero-weights-flag": {
       "state": "ENABLED",
       "variants": {
-        "true": "true",
-        "false": "false",
+        "one": "one",
+        "two": "two",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"fractional": [
-            {"var": "targetingKey"},
-            ["one", 0],
-            ["two", 0]
-          ]},
-          "true", "false"
+        "fractional": [
+          {"var": "targetingKey"},
+          ["one", 0],
+          ["two", 0]
         ]
       }
     },
@@ -196,16 +166,12 @@
     "semver-wrong-args-flag": {
       "state": "ENABLED",
       "variants": {
-        "true": "true",
-        "false": "false",
+        "match": "match",
         "fallback": "fallback"
       },
       "defaultVariant": "fallback",
       "targeting": {
-        "if": [
-          {"sem_ver": [{"var": "version"}, "="]},
-          "true", "false"
-        ]
+        "sem_ver": [{"var": "version"}, "="]
       }
     }
   }


### PR DESCRIPTION
The `if` wrappers were added in [#356](https://github.com/open-feature/flagd-testbed/pull/356/commits/604df926b3b1c6caf5133a25e27c3bda87b2f90a) (my bad), but json-logic's `if` coerces its condition to a boolean; `null` and `false` are both falsy, so the `if` always selects the `"false"` variant for both cases. This makes it impossible to verify that operators return `null` (not `false`) on error, which is the entire point of the `@operator-errors` scenarios.

By using the operator directly as the top-level targeting expression, a `null` return propagates to the evaluator, which falls back to `defaultVariant` with reason `DEFAULT`; a `false` return would resolve to the `"false"` variant with reason `TARGETING_MATCH`. The distinction is preserved.

---

I tested this locally and with this and the expected fixes, I was able to get the test suite fully updated in in-process mode! No more inconsistencies!