### PR TITLE
feat: add disabled flag evaluation test scenarios

### DIFF
--- a/evaluator/flags/testkit-flags.json
+++ b/evaluator/flags/testkit-flags.json
@@ -655,6 +655,50 @@
       "targeting": {
         "sem_ver": [{"var": "version"}, "="]
       }
+    },
+    "disabled-boolean-flag": {
+      "state": "DISABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
+    },
+    "disabled-string-flag": {
+      "state": "DISABLED",
+      "variants": {
+        "greeting": "hi",
+        "parting": "bye"
+      },
+      "defaultVariant": "greeting"
+    },
+    "disabled-integer-flag": {
+      "state": "DISABLED",
+      "variants": {
+        "one": 1,
+        "ten": 10
+      },
+      "defaultVariant": "ten"
+    },
+    "disabled-float-flag": {
+      "state": "DISABLED",
+      "variants": {
+        "tenth": 0.1,
+        "half": 0.5
+      },
+      "defaultVariant": "half"
+    },
+    "disabled-object-flag": {
+      "state": "DISABLED",
+      "variants": {
+        "empty": {},
+        "template": {
+          "showImages": true,
+          "title": "Check out these pics!",
+          "imagesPerPage": 100
+        }
+      },
+      "defaultVariant": "template"
     }
   },
   "$evaluators": {

--- a/evaluator/gherkin/disabled.feature
+++ b/evaluator/gherkin/disabled.feature
@@ -1,0 +1,31 @@
+@disabled
+Feature: Evaluator disabled flag evaluation
+
+  # Validates that disabled flags resolve with reason=DISABLED and no value/variant.
+  # The evaluator omits value and variant; the SDK substitutes the caller-provided default.
+  # Flags are configured in evaluator/flags/testkit-flags.json.
+  # Relates to: https://github.com/open-feature/flagd/issues/1965
+
+  Scenario Outline: Resolve disabled flag returns reason DISABLED with absent value
+    Given an evaluator
+    And a <type>-flag with key "<key>" and a fallback value "<default>"
+    When the flag was evaluated with details
+    Then the resolved value should be absent
+    And the reason should be "DISABLED"
+
+    Examples: Boolean evaluations
+      | key                   | type    | default |
+      | disabled-boolean-flag | Boolean | false   |
+
+    Examples: String evaluations
+      | key                  | type   | default |
+      | disabled-string-flag | String | bye     |
+
+    Examples: Number evaluations
+      | key                   | type    | default |
+      | disabled-integer-flag | Integer | 1       |
+      | disabled-float-flag   | Float   | 0.1     |
+
+    Examples: Object evaluations
+      | key                  | type   | default |
+      | disabled-object-flag | Object | {}      |

--- a/evaluator/gherkin/disabled.feature
+++ b/evaluator/gherkin/disabled.feature
@@ -1,16 +1,16 @@
 @disabled
 Feature: Evaluator disabled flag evaluation
 
-  # Validates that disabled flags resolve with reason=DISABLED and no value/variant.
-  # The evaluator omits value and variant; the SDK substitutes the caller-provided default.
+  # Validates that disabled flags resolve with reason=DISABLED. The evaluator
+  # substitutes the caller-provided default value and omits the variant.
   # Flags are configured in evaluator/flags/testkit-flags.json.
   # Relates to: https://github.com/open-feature/flagd/issues/1965
 
-  Scenario Outline: Resolve disabled flag returns reason DISABLED with absent value
+  Scenario Outline: Resolve disabled flag returns reason DISABLED with the default value
     Given an evaluator
     And a <type>-flag with key "<key>" and a fallback value "<default>"
     When the flag was evaluated with details
-    Then the resolved value should be absent
+    Then the resolved details value should be "<default>"
     And the reason should be "DISABLED"
 
     Examples: Boolean evaluations

--- a/evaluator/gherkin/disabled.feature
+++ b/evaluator/gherkin/disabled.feature
@@ -13,19 +13,10 @@ Feature: Evaluator disabled flag evaluation
     Then the resolved details value should be "<default>"
     And the reason should be "DISABLED"
 
-    Examples: Boolean evaluations
+    Examples:
       | key                   | type    | default |
       | disabled-boolean-flag | Boolean | false   |
-
-    Examples: String evaluations
-      | key                  | type   | default |
-      | disabled-string-flag | String | bye     |
-
-    Examples: Number evaluations
-      | key                   | type    | default |
+      | disabled-string-flag  | String  | bye     |
       | disabled-integer-flag | Integer | 1       |
       | disabled-float-flag   | Float   | 0.1     |
-
-    Examples: Object evaluations
-      | key                  | type   | default |
-      | disabled-object-flag | Object | {}      |
+      | disabled-object-flag  | Object  | {}      |

--- a/flagd/Dockerfile
+++ b/flagd/Dockerfile
@@ -1,4 +1,4 @@
-ARG FLAGD_BASE_IMAGE=ghcr.io/open-feature/flagd:v0.15.5
+ARG FLAGD_BASE_IMAGE=ghcr.io/open-feature/flagd:v0.16.0
 ARG TARGETARCH
 
 FROM ${FLAGD_BASE_IMAGE} AS flagd

--- a/flags/disabled-flags.json
+++ b/flags/disabled-flags.json
@@ -1,0 +1,56 @@
+{
+  "flags": {
+    "disabled-boolean-flag": {
+      "state": "DISABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
+    },
+    "disabled-string-flag": {
+      "state": "DISABLED",
+      "variants": {
+        "greeting": "hi",
+        "parting": "bye"
+      },
+      "defaultVariant": "greeting"
+    },
+    "disabled-integer-flag": {
+      "state": "DISABLED",
+      "variants": {
+        "one": 1,
+        "ten": 10
+      },
+      "defaultVariant": "ten"
+    },
+    "disabled-float-flag": {
+      "state": "DISABLED",
+      "variants": {
+        "tenth": 0.1,
+        "half": 0.5
+      },
+      "defaultVariant": "half"
+    },
+    "disabled-object-flag": {
+      "state": "DISABLED",
+      "variants": {
+        "empty": {},
+        "template": {
+          "showImages": true,
+          "title": "Check out these pics!",
+          "imagesPerPage": 100
+        }
+      },
+      "defaultVariant": "template"
+    },
+    "cross-flagset-flag": {
+      "state": "DISABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
+    }
+  }
+}

--- a/flags/selector-flags.json
+++ b/flags/selector-flags.json
@@ -16,5 +16,8 @@
       },
       "defaultVariant": "on"
     }
+  },
+  "metadata": {
+    "flagSetId": "selector-set"
   }
 }

--- a/flags/selector-flags.json
+++ b/flags/selector-flags.json
@@ -7,6 +7,14 @@
         "bar": "bar"
       },
       "defaultVariant": "foo"
+    },
+    "cross-flagset-flag": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "on"
     }
   }
 }

--- a/gherkin/disabled.feature
+++ b/gherkin/disabled.feature
@@ -1,11 +1,10 @@
-@disabled @in-process
+@disabled @in-process @rpc
 Feature: Disabled flag evaluation
 
   # Test coverage for disabled flag behavior. A flag with state=DISABLED resolves
   # successfully with reason=DISABLED and no value or variant (SDK uses code default).
   # Relates to: https://github.com/open-feature/flagd/issues/1965
 
-  @rpc
   Scenario Outline: Evaluating a disabled flag returns reason DISABLED and code default
     Given an option "cache" of type "CacheType" with value "disabled"
     And a stable flagd provider

--- a/gherkin/disabled.feature
+++ b/gherkin/disabled.feature
@@ -1,0 +1,44 @@
+Feature: Disabled flag evaluation
+
+  # Test coverage for disabled flag behavior. A flag with state=DISABLED resolves
+  # successfully with reason=DISABLED and no value or variant (SDK uses code default).
+  # Relates to: https://github.com/open-feature/flagd/issues/1965
+
+  @rpc @in-process
+  Scenario Outline: Evaluating a disabled flag returns reason DISABLED and code default
+    Given an option "cache" of type "CacheType" with value "disabled"
+    And a stable flagd provider
+    And a <type>-flag with key "<key>" and a default value "<default>"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<default>"
+    And the reason should be "DISABLED"
+
+    Examples:
+      | key                   | type    | default |
+      | disabled-boolean-flag | Boolean | false   |
+      | disabled-string-flag  | String  | bye     |
+      | disabled-integer-flag | Integer | 1       |
+      | disabled-float-flag   | Float   | 0.1     |
+
+  @rpc
+  Scenario: Bulk evaluation includes disabled flags with reason DISABLED
+    Given an option "cache" of type "CacheType" with value "disabled"
+    And a stable flagd provider
+    When all flags were evaluated in bulk
+    Then the bulk evaluation result should contain a flag with key "disabled-boolean-flag" and reason "DISABLED"
+    And the bulk evaluation result should contain a flag with key "boolean-flag" and reason "STATIC"
+
+  @in-process
+  Scenario Outline: Flag disabled in one flag set, enabled in another
+    Given an option "cache" of type "CacheType" with value "disabled"
+    And an option "selector" of type "String" with value "<selector>"
+    And a stable flagd provider
+    And a Boolean-flag with key "cross-flagset-flag" and a default value "false"
+    When the flag was evaluated with details
+    Then the resolved details value should be "<resolved_value>"
+    And the reason should be "<reason>"
+
+    Examples:
+      | selector                     | resolved_value | reason   |
+      | rawflags/disabled-flags.json | false          | DISABLED |
+      | rawflags/selector-flags.json | true           | STATIC   |

--- a/gherkin/disabled.feature
+++ b/gherkin/disabled.feature
@@ -2,7 +2,8 @@
 Feature: Disabled flag evaluation
 
   # Test coverage for disabled flag behavior. A flag with state=DISABLED resolves
-  # successfully with reason=DISABLED and no value or variant (SDK uses code default).
+  # successfully with reason=DISABLED; the evaluator substitutes the caller-provided
+  # default value and omits the variant.
   # Relates to: https://github.com/open-feature/flagd/issues/1965
 
   Scenario Outline: Evaluating a disabled flag returns reason DISABLED and code default

--- a/gherkin/disabled.feature
+++ b/gherkin/disabled.feature
@@ -19,6 +19,7 @@ Feature: Disabled flag evaluation
       | disabled-string-flag  | String  | bye     |
       | disabled-integer-flag | Integer | 1       |
       | disabled-float-flag   | Float   | 0.1     |
+      | disabled-object-flag  | Object  | {}      |
 
   @rpc
   Scenario: Bulk evaluation includes disabled flags with reason DISABLED
@@ -40,5 +41,5 @@ Feature: Disabled flag evaluation
 
     Examples:
       | selector                     | resolved_value | reason   |
-      | rawflags/disabled-flags.json | false          | DISABLED |
+      | flags/allFlags.json          | false          | DISABLED |
       | rawflags/selector-flags.json | true           | STATIC   |

--- a/gherkin/disabled.feature
+++ b/gherkin/disabled.feature
@@ -1,3 +1,4 @@
+@disabled
 Feature: Disabled flag evaluation
 
   # Test coverage for disabled flag behavior. A flag with state=DISABLED resolves
@@ -20,14 +21,6 @@ Feature: Disabled flag evaluation
       | disabled-integer-flag | Integer | 1       |
       | disabled-float-flag   | Float   | 0.1     |
       | disabled-object-flag  | Object  | {}      |
-
-  @rpc
-  Scenario: Bulk evaluation includes disabled flags with reason DISABLED
-    Given an option "cache" of type "CacheType" with value "disabled"
-    And a stable flagd provider
-    When all flags were evaluated in bulk
-    Then the bulk evaluation result should contain a flag with key "disabled-boolean-flag" and reason "DISABLED"
-    And the bulk evaluation result should contain a flag with key "boolean-flag" and reason "STATIC"
 
   @in-process
   Scenario Outline: Flag disabled in one flag set, enabled in another

--- a/gherkin/disabled.feature
+++ b/gherkin/disabled.feature
@@ -1,11 +1,11 @@
-@disabled
+@disabled @in-process
 Feature: Disabled flag evaluation
 
   # Test coverage for disabled flag behavior. A flag with state=DISABLED resolves
   # successfully with reason=DISABLED and no value or variant (SDK uses code default).
   # Relates to: https://github.com/open-feature/flagd/issues/1965
 
-  @rpc @in-process
+  @rpc
   Scenario Outline: Evaluating a disabled flag returns reason DISABLED and code default
     Given an option "cache" of type "CacheType" with value "disabled"
     And a stable flagd provider
@@ -22,7 +22,6 @@ Feature: Disabled flag evaluation
       | disabled-float-flag   | Float   | 0.1     |
       | disabled-object-flag  | Object  | {}      |
 
-  @in-process
   Scenario Outline: Flag disabled in one flag set, enabled in another
     Given an option "cache" of type "CacheType" with value "disabled"
     And an option "selector" of type "String" with value "<selector>"


### PR DESCRIPTION
## Summary

- New `flags/disabled-flags.json`: 5 typed disabled flags (boolean, string, integer, float, object) + `cross-flagset-flag`
- `flags/selector-flags.json`: adds `cross-flagset-flag` (ENABLED) and `metadata.flagSetId: "selector-set"` for cross-flag-set coverage
- `evaluator/flags/testkit-flags.json`: appends the 5 disabled flag definitions
- `gherkin/disabled.feature`: provider-level scenarios (`@in-process @rpc`)
  - disabled flag resolves with `reason=DISABLED` and the caller-provided default
  - same flag DISABLED in one flag set, ENABLED in another (via selector)
- `evaluator/gherkin/disabled.feature`: matching evaluator-level scenario
- `flagd/Dockerfile`: bump base image to `flagd:v0.16.0`

## Motivation

Part of open-feature/flagd#1965. ADR: [docs/architecture-decisions/disabled-flag-evaluation.md](https://github.com/open-feature/flagd/blob/main/docs/architecture-decisions/disabled-flag-evaluation.md).

Previously a disabled flag returned `reason=ERROR` / `errorCode=FLAG_DISABLED`. As of open-feature/flagd#1968 it returns `reason=DISABLED` with the caller's default value; this PR adds the testbed coverage to verify that across providers.

## Related

Part of: open-feature/flagd#1965
Closes: #375
