### PR TITLE
fix: run testbed image as root to support bind-mounted /flags

### DIFF
--- a/flagd/Dockerfile
+++ b/flagd/Dockerfile
@@ -42,12 +42,6 @@ COPY --from=certs custom-root-cert.crt /ssl/
 
 RUN mkdir "flags"
 
-# NOTE: intentionally runs as root. launchpad writes generated flag configs into
-# /flags, which consumers bind-mount from host dirs of arbitrary ownership (see
-# docker-compose.yaml); a non-root user cannot write there. This is a test-only
-# fixture, not a deployed workload.
-
-
 LABEL org.opencontainers.image.source="https://github.com/open-feature/flagd-testbed"
 
 ENTRYPOINT ["./launchpad"]

--- a/flagd/Dockerfile
+++ b/flagd/Dockerfile
@@ -42,10 +42,10 @@ COPY --from=certs custom-root-cert.crt /ssl/
 
 RUN mkdir "flags"
 
-# run as non-root
-RUN adduser -D -H -u 10001 testbed \
-    && chown -R testbed:testbed /flags /rawflags /configs /ssl
-USER testbed
+# NOTE: intentionally runs as root. launchpad writes generated flag configs into
+# /flags, which consumers bind-mount from host dirs of arbitrary ownership (see
+# docker-compose.yaml); a non-root user cannot write there. This is a test-only
+# fixture, not a deployed workload.
 
 
 LABEL org.opencontainers.image.source="https://github.com/open-feature/flagd-testbed"


### PR DESCRIPTION
The non-root change in #381 (v3.8.1) breaks consumers that bind-mount a host `/flags` dir: launchpad runs as `testbed` and cannot write `allFlags.json` into the root-owned mount, so the container exits 1 (surfaced in flagd's e2e). Reverting to root; the busybox-root Sonar hotspot should be marked Safe since this is a test fixture that must write to consumer-provided bind mounts of arbitrary ownership.